### PR TITLE
Add CJK/full-width character support for correct terminal alignment

### DIFF
--- a/src/termaid/cli.py
+++ b/src/termaid/cli.py
@@ -17,8 +17,9 @@ def _get_version() -> str:
 
 
 def _max_line_width(text: str) -> int:
-    """Return the width of the longest line in text."""
-    return max((len(line) for line in text.split("\n")), default=0)
+    """Return the display width of the longest line in text."""
+    from .renderer.textwidth import display_width
+    return max((display_width(line) for line in text.split("\n")), default=0)
 
 
 def _auto_fit(
@@ -202,12 +203,33 @@ def main(argv: list[str] | None = None) -> int:
         help="Render sample diagrams. Use 'all' or a type name (flowchart, sequence, etc.).",
     )
     parser.add_argument(
+        "--cjk",
+        action="store_true",
+        default=None,
+        help="Treat ambiguous-width markers (◇●▲▼ etc.) as 2 columns. "
+             "Auto-detected from locale; use this flag to force it on.",
+    )
+    parser.add_argument(
+        "--no-cjk",
+        action="store_true",
+        default=False,
+        help="Disable CJK ambiguous-width mode even if auto-detected.",
+    )
+    parser.add_argument(
         "--version",
         action="version",
         version=f"%(prog)s {_get_version()}",
     )
 
     args = parser.parse_args(argv)
+
+    # Apply CJK mode override before any rendering
+    from .renderer.textwidth import set_cjk_mode, _detect_cjk
+    if args.no_cjk:
+        set_cjk_mode(False)
+    elif args.cjk:
+        set_cjk_mode(True)
+    # else: keep auto-detected default
 
     if args.themes:
         return _list_themes()

--- a/src/termaid/layout/placement.py
+++ b/src/termaid/layout/placement.py
@@ -218,7 +218,7 @@ def _expand_gaps_for_edge_labels(graph: Graph, layout: GridLayout) -> None:
     for edge in graph.edges:
         if not edge.label:
             continue
-        label_len = len(edge.label)
+        label_len = display_width(edge.label)
 
         src_p = layout.placements.get(edge.source)
         tgt_p = layout.placements.get(edge.target)

--- a/src/termaid/layout/placement.py
+++ b/src/termaid/layout/placement.py
@@ -6,6 +6,7 @@ heights based on label content, and normalizing sizes within layers.
 from __future__ import annotations
 
 from ..graph.model import Direction, Graph
+from ..renderer.textwidth import display_width
 from .grid import (
     STRIDE,
     MAX_LABEL_WIDTH,
@@ -80,7 +81,7 @@ def _word_wrap(text: str, max_width: int) -> list[str]:
     current_line = words[0]
 
     for word in words[1:]:
-        if len(current_line) + 1 + len(word) <= max_width:
+        if display_width(current_line) + 1 + display_width(word) <= max_width:
             current_line += " " + word
         else:
             lines.append(current_line)
@@ -143,7 +144,7 @@ def compute_sizes(
         # Word-wrap lines that exceed max width
         wrapped_lines: list[str] = []
         for line in lines:
-            if len(line) <= MAX_LABEL_WIDTH:
+            if display_width(line) <= MAX_LABEL_WIDTH:
                 wrapped_lines.append(line)
             else:
                 wrapped_lines.extend(_word_wrap(line, MAX_LABEL_WIDTH))
@@ -152,7 +153,7 @@ def compute_sizes(
         if len(wrapped_lines) > 1 and wrapped_lines != lines:
             node.label = "\\n".join(wrapped_lines)
 
-        text_width = max(len(l) for l in wrapped_lines) if wrapped_lines else 0
+        text_width = max(display_width(l) for l in wrapped_lines) if wrapped_lines else 0
         text_height = len(wrapped_lines)
 
         content_width = text_width + padding_x  # padding on each side

--- a/src/termaid/layout/subgraphs.py
+++ b/src/termaid/layout/subgraphs.py
@@ -6,6 +6,7 @@ and computes subgraph bounding boxes after node placement.
 from __future__ import annotations
 
 from ..graph.model import Direction, Graph, Subgraph
+from ..renderer.textwidth import display_width
 from .grid import (
     SG_BORDER_PAD,
     SG_GAP_PER_LEVEL,
@@ -161,7 +162,7 @@ def compute_subgraph_bounds(
             return None
 
         content_width = int(max_x - min_x) + SG_BORDER_PAD * 2
-        label_width = len(sg.label) + 4
+        label_width = display_width(sg.label) + 4
         final_width = max(content_width, label_width)
 
         bounds = SubgraphBounds(

--- a/src/termaid/renderer/blockdiagram.py
+++ b/src/termaid/renderer/blockdiagram.py
@@ -9,6 +9,7 @@ from ..model.blockdiagram import Block, BlockDiagram, BlockLink
 from .canvas import Canvas
 from .charset import ASCII, UNICODE, CharSet
 from .shapes import SHAPE_RENDERERS
+from .textwidth import display_width
 
 # Layout constants
 _BLOCK_PAD = 2
@@ -119,7 +120,7 @@ def _compute_block_size(block: Block, cs: CharSet, padding_x: int = _BLOCK_PAD, 
         return max(w, _MIN_BLOCK_W), max(h, _MIN_BLOCK_H)
 
     label = block.label or block.id
-    w = max(len(label) + padding_x * 2, _MIN_BLOCK_W)
+    w = max(display_width(label) + padding_x * 2, _MIN_BLOCK_W)
     h = _MIN_BLOCK_H
     return w, h
 
@@ -332,7 +333,7 @@ def _draw_groups(
 
         # Draw group label (skip for anonymous groups)
         if block.label:
-            label_col = x + (w - len(block.label)) // 2
+            label_col = x + (w - display_width(block.label)) // 2
             canvas.put_text(y + 1, label_col, block.label, style="label")
 
         # Recurse for nested groups within children
@@ -429,7 +430,7 @@ def _draw_link(
     if link.label:
         mid_r = (r1 + r2) // 2
         mid_c = (c1 + c2) // 2
-        label_col = mid_c - len(link.label) // 2
+        label_col = mid_c - display_width(link.label) // 2
         canvas.put_text(mid_r, label_col, link.label, style="edge_label")
 
 

--- a/src/termaid/renderer/canvas.py
+++ b/src/termaid/renderer/canvas.py
@@ -8,6 +8,7 @@ and the correct junction character is derived from the combined directions.
 from __future__ import annotations
 
 from .charset import CharSet, UNICODE
+from .textwidth import char_width
 
 
 # Direction bitfield constants
@@ -40,6 +41,12 @@ _DIRECTION_TO_CHAR: dict[int, str] = {
 # Reverse mapping: infer direction bitfield from a box-drawing character.
 # Used when callers place box chars without explicit direction info
 # (e.g. node borders, subgraph borders, shape renderers).
+# Sentinel for the second cell of a wide (2-column) character.
+# When a character with display width 2 is placed at column *c*, the cell
+# at column *c+1* is set to this value so that ``to_string`` skips it and
+# the terminal columns stay aligned.
+_WIDE_CONT = ""
+
 _CHAR_TO_DIRECTIONS: dict[str, int] = {
     # Standard single-line
     "─": LEFT | RIGHT,
@@ -148,20 +155,35 @@ class Canvas:
 
         Protected cells (node borders) only accept merges that add new
         directions. Plain overwrites are blocked.
+
+        Wide characters (CJK etc.) automatically claim the next column by
+        placing a ``_WIDE_CONT`` sentinel at ``col + 1``.
         """
         if not (0 <= row < self.height and 0 <= col < self.width):
             return
         if ch == " ":
             return
 
+        # -- Wide-character bookkeeping (before placement) --
+        existing = self._grid[row][col]
+
+        # If we are overwriting a continuation cell, break the parent wide char
+        if existing == _WIDE_CONT and col > 0:
+            self._grid[row][col - 1] = " "
+            self._directions[row][col - 1] = 0
+
+        # If the existing cell is itself wide, clear its continuation
+        if existing != _WIDE_CONT and existing != " " and col + 1 < self.width:
+            if self._grid[row][col + 1] == _WIDE_CONT:
+                self._grid[row][col + 1] = " "
+                self._directions[row][col + 1] = 0
+
         # Infer directions from the character if not otherwise known
         new_dirs = _CHAR_TO_DIRECTIONS.get(ch, 0)
-
-        existing = self._grid[row][col]
         existing_dirs = self._directions[row][col]
 
-        if existing == " ":
-            # Empty cell: just place
+        if existing == " " or existing == _WIDE_CONT:
+            # Empty / continuation cell: just place
             self._grid[row][col] = ch
             self._directions[row][col] = new_dirs
         elif merge and existing_dirs and new_dirs:
@@ -190,10 +212,30 @@ class Canvas:
         if style:
             self._style_grid[row][col] = style
 
+        # -- Wide-character bookkeeping (after placement) --
+        if char_width(ch) == 2 and col + 1 < self.width:
+            # Claim the next column as a continuation of this wide char.
+            # If that cell is itself a wide char, clear *its* continuation first.
+            next_ch = self._grid[row][col + 1]
+            if next_ch != _WIDE_CONT and next_ch != " " and col + 2 < self.width:
+                if self._grid[row][col + 2] == _WIDE_CONT:
+                    self._grid[row][col + 2] = " "
+                    self._directions[row][col + 2] = 0
+            self._grid[row][col + 1] = _WIDE_CONT
+            self._style_grid[row][col + 1] = style if style else self._style_grid[row][col + 1]
+            self._directions[row][col + 1] = 0
+            self._protected[row][col + 1] = self._protected[row][col]
+
     def put_text(self, row: int, col: int, text: str, style: str = "") -> None:
-        """Place a string of characters starting at (row, col)."""
-        for i, ch in enumerate(text):
-            self.put(row, col + i, ch, merge=False, style=style)
+        """Place a string of characters starting at (row, col).
+
+        Advances by the display width of each character so that wide
+        (CJK / full-width) characters correctly occupy two columns.
+        """
+        offset = 0
+        for ch in text:
+            self.put(row, col + offset, ch, merge=False, style=style)
+            offset += char_width(ch)
 
     def put_styled_text(self, row: int, col: int, segments: list[tuple[str, str]]) -> None:
         """Place text with per-segment style keys. Each segment is (text, style_key)."""
@@ -201,7 +243,7 @@ class Canvas:
         for text, style in segments:
             for ch in text:
                 self.put(row, col + offset, ch, merge=False, style=style)
-                offset += 1
+                offset += char_width(ch)
 
     def get_style(self, row: int, col: int) -> str:
         """Get the style key at a position."""
@@ -210,12 +252,18 @@ class Canvas:
         return "default"
 
     def to_styled_pairs(self) -> list[list[tuple[str, str]]]:
-        """Return (char, style_key) pairs for each cell."""
+        """Return (char, style_key) pairs for each cell.
+
+        Continuation cells from wide characters are skipped.
+        """
         result: list[list[tuple[str, str]]] = []
         for r in range(self.height):
             row_pairs: list[tuple[str, str]] = []
             for c in range(self.width):
-                row_pairs.append((self._grid[r][c], self._style_grid[r][c]))
+                ch = self._grid[r][c]
+                if ch == _WIDE_CONT:
+                    continue
+                row_pairs.append((ch, self._style_grid[r][c]))
             result.append(row_pairs)
         return result
 
@@ -232,10 +280,15 @@ class Canvas:
             self.put(r, col, ch, style=style)
 
     def to_string(self) -> str:
-        """Convert canvas to a string, trimming trailing whitespace per line."""
+        """Convert canvas to a string, trimming trailing whitespace per line.
+
+        Continuation cells (``_WIDE_CONT``) left by wide characters are
+        skipped so that the terminal renders each wide glyph in exactly
+        two columns.
+        """
         lines: list[str] = []
         for row in self._grid:
-            line = "".join(row).rstrip()
+            line = "".join(ch for ch in row if ch != _WIDE_CONT).rstrip()
             lines.append(line)
         # Remove trailing empty lines
         while lines and not lines[-1]:
@@ -277,6 +330,7 @@ class Canvas:
             self._grid[r].reverse()
             self._style_grid[r].reverse()
             self._directions[r].reverse()
+            self._protected[r].reverse()
         _flip_map = {
             "┌": "┐", "┐": "┌", "└": "┘", "┘": "└",
             "├": "┤", "┤": "├", "┬": "┬", "┴": "┴",
@@ -286,10 +340,28 @@ class Canvas:
             "╔": "╗", "╗": "╔", "╚": "╝", "╝": "╚",
         }
         for r in range(self.height):
+            # Fix wide-char continuations: after reverse, CONT is before its
+            # parent wide char.  Swap them so CONT follows its parent again.
+            row = self._grid[r]
+            c = 0
+            while c < self.width:
+                if row[c] == _WIDE_CONT and c + 1 < self.width and char_width(row[c + 1]) == 2:
+                    # Swap continuation to come after the wide char
+                    row[c], row[c + 1] = row[c + 1], row[c]
+                    self._style_grid[r][c], self._style_grid[r][c + 1] = (
+                        self._style_grid[r][c + 1], self._style_grid[r][c]
+                    )
+                    self._protected[r][c], self._protected[r][c + 1] = (
+                        self._protected[r][c + 1], self._protected[r][c]
+                    )
+                    c += 2  # skip past the pair
+                else:
+                    c += 1
+
             for c in range(self.width):
-                ch = self._grid[r][c]
+                ch = row[c]
                 if ch in _flip_map:
-                    self._grid[r][c] = _flip_map[ch]
+                    row[c] = _flip_map[ch]
                 # Flip direction bits: LEFT <-> RIGHT
                 d = self._directions[r][c]
                 if d:

--- a/src/termaid/renderer/canvas.py
+++ b/src/termaid/renderer/canvas.py
@@ -167,6 +167,13 @@ class Canvas:
         # -- Wide-character bookkeeping (before placement) --
         existing = self._grid[row][col]
 
+        # Protected wide characters and their continuations must not be
+        # broken by edge routing or other overwrites.
+        if existing == _WIDE_CONT and self._protected[row][col]:
+            return
+        if self._protected[row][col] and char_width(existing) == 2:
+            return
+
         # If we are overwriting a continuation cell, break the parent wide char
         if existing == _WIDE_CONT and col > 0:
             self._grid[row][col - 1] = " "

--- a/src/termaid/renderer/classdiagram.py
+++ b/src/termaid/renderer/classdiagram.py
@@ -10,6 +10,7 @@ from collections import deque
 from ..model.classdiagram import ClassDef, ClassDiagram, Note, Relationship
 from .canvas import Canvas
 from .charset import ASCII, UNICODE, CharSet
+from .textwidth import display_width
 
 # ── layout constants ──────────────────────────────────────────────
 _CLASS_PAD = 2       # horizontal padding inside class box
@@ -52,7 +53,7 @@ def _compute_box_size(cls: ClassDef, padding_x: int = _CLASS_PAD) -> tuple[int, 
         member_lines.append(_format_member(m))
 
     all_lines = lines + member_lines
-    max_text = max((len(l) for l in all_lines), default=0)
+    max_text = max((display_width(l) for l in all_lines), default=0)
     width = max(max_text + padding_x * 2, _MIN_BOX_WIDTH)
 
     # Height: top border + name rows + dividers + member rows + bottom border
@@ -101,11 +102,11 @@ def _draw_class_box(
     row = y + 1
     if cls.annotation:
         ann_text = f"\u00ab{cls.annotation}\u00bb"
-        ann_col = x + (width - len(ann_text)) // 2
+        ann_col = x + (width - display_width(ann_text)) // 2
         canvas.put_text(row, ann_col, ann_text, style="label")
         row += 1
 
-    name_col = x + (width - len(cls.name)) // 2
+    name_col = x + (width - display_width(cls.name)) // 2
     canvas.put_text(row, name_col, cls.name, style="label")
     row += 1
 
@@ -239,7 +240,7 @@ def _compute_layout(
     for rel in diagram.relationships:
         s, t = rel.source, rel.target
         if s in layer_of and t in layer_of and layer_of[s] == layer_of[t]:
-            pair_g = len(rel.label) + 4 if rel.label else gap
+            pair_g = display_width(rel.label) + 4 if rel.label else gap
             pair_g = max(pair_g, gap)
             key = (min(s, t), max(s, t))
             pair_gap[key] = max(pair_gap.get(key, gap), pair_g)
@@ -507,7 +508,7 @@ def _draw_relationship(
         mid_c = (start_col + end_col) // 2
         if start_row == end_row:
             # Horizontal: label above the line
-            label_col = mid_c - len(rel.label) // 2
+            label_col = mid_c - display_width(rel.label) // 2
             canvas.put_text(mid_r - 1, label_col, rel.label, style="edge_label")
         else:
             # Vertical or L-shaped: label to the right of midpoint
@@ -700,7 +701,7 @@ def render_class_diagram(diagram: ClassDiagram, *, use_ascii: bool = False, padd
         tx, ty = positions[rel.target]
         tw, _ = sizes[rel.target]
         mid_c = (sx + sw // 2 + tx + tw // 2) // 2
-        label_end = mid_c + 2 + len(rel.label)
+        label_end = mid_c + 2 + display_width(rel.label)
         width = max(width, label_end + _MARGIN)
 
     exit_offsets = _compute_exit_offsets(diagram, layer_of)

--- a/src/termaid/renderer/draw.py
+++ b/src/termaid/renderer/draw.py
@@ -19,6 +19,7 @@ from ..routing.router import AttachDir, RoutedEdge, route_edges
 from .canvas import Canvas
 from .charset import ASCII, UNICODE, CharSet
 from .shapes import SHAPE_RENDERERS, draw_rectangle
+from .textwidth import display_width
 
 
 def render_graph(
@@ -199,7 +200,7 @@ def _draw_nodes(canvas: Canvas, graph: Graph, layout: GridLayout, cs: CharSet) -
         # Overwrite label with styled text if markdown segments exist
         if node.label_segments:
             label_row = p.draw_y + p.draw_height // 2
-            total_len = sum(len(seg.text) for seg in node.label_segments)
+            total_len = sum(display_width(seg.text) for seg in node.label_segments)
             label_col = p.draw_x + (p.draw_width - total_len) // 2
             styled_segs: list[tuple[str, str]] = []
             for seg in node.label_segments:
@@ -487,7 +488,7 @@ def _try_place_label(
     placed: list[tuple[int, int, int]],
 ) -> bool:
     """Try to place a label at (row, col). Returns True if placed."""
-    col_end = col + len(label)
+    col_end = col + display_width(label)
     if col < 0 or row < 0:
         return False
     if _label_overlaps(row, col, col_end, placed):
@@ -538,7 +539,7 @@ def _try_place_on_segment(
     prefer_left: explicitly prefer the left side for vertical segments.
     bias_target: place closer to the target end (2/3) instead of midpoint.
     """
-    label_len = len(label)
+    label_len = display_width(label)
 
     if x1 == x2 and abs(y2 - y1) >= 2:
         # Vertical segment — place beside the line.
@@ -612,7 +613,7 @@ def _draw_edge_label(
     if not label:
         return
 
-    label_len = len(label)
+    label_len = display_width(label)
     path = re.draw_path
 
     # Build segment list ordered by preference: post-turn segments first,
@@ -669,7 +670,7 @@ def _draw_notes(canvas: Canvas, graph: Graph, layout: GridLayout, cs: CharSet) -
         p = layout.placements[note.target]
 
         lines = note.text.split("\n")
-        note_width = max(len(line) for line in lines) + 4
+        note_width = max(display_width(line) for line in lines) + 4
         note_height = len(lines) + 2
 
         if note.position == "rightof":

--- a/src/termaid/renderer/erdiagram.py
+++ b/src/termaid/renderer/erdiagram.py
@@ -10,6 +10,7 @@ from collections import deque
 from ..model.erdiagram import Entity, ERDiagram, Relationship
 from .canvas import Canvas
 from .charset import ASCII, UNICODE, CharSet
+from .textwidth import display_width
 
 # ── layout constants ──────────────────────────────────────────────
 _PAD = 2             # horizontal padding inside entity box
@@ -57,7 +58,7 @@ def _compute_box_size(entity: Entity, padding_x: int = _PAD) -> tuple[int, int]:
         attr_lines.append(_format_attribute(attr))
 
     all_lines = lines + attr_lines
-    max_text = max((len(l) for l in all_lines), default=0)
+    max_text = max((display_width(l) for l in all_lines), default=0)
     width = max(max_text + padding_x * 2, _MIN_BOX_WIDTH)
 
     # Height: top border + name row + [divider + attr rows] + bottom border
@@ -96,7 +97,7 @@ def _draw_entity_box(
     # Name (centered)
     row = y + 1
     name = entity.display_name
-    name_col = x + (width - len(name)) // 2
+    name_col = x + (width - display_width(name)) // 2
     canvas.put_text(row, name_col, name, style="label")
     row += 1
 
@@ -193,7 +194,7 @@ def _compute_layout(
     for rel in diagram.relationships:
         s, t = rel.entity1, rel.entity2
         if s in layer_of and t in layer_of and layer_of[s] == layer_of[t]:
-            pair_g = len(rel.label) + 4 if rel.label else gap
+            pair_g = display_width(rel.label) + 4 if rel.label else gap
             pair_g = max(pair_g, gap)
             key = (min(s, t), max(s, t))
             pair_gap[key] = max(pair_gap.get(key, gap), pair_g)
@@ -208,7 +209,7 @@ def _compute_layout(
             card2_len = len(_card_text(rel.card2))
             needed = max(needed, card1_len + card2_len + 4)
             if rel.label:
-                needed = max(needed, len(rel.label) + 4)
+                needed = max(needed, display_width(rel.label) + 4)
             cross_layer_gap = max(cross_layer_gap, needed)
 
     is_lr = diagram.direction == "LR"
@@ -395,7 +396,7 @@ def _draw_relationship(
         if card1_text:
             canvas.put_text(start_row - 1, start_col + 1, card1_text, style="edge_label")
         if card2_text:
-            canvas.put_text(end_row - 1, end_col - len(card2_text), card2_text, style="edge_label")
+            canvas.put_text(end_row - 1, end_col - display_width(card2_text), card2_text, style="edge_label")
     else:
         # Vertical connection: cardinality to the right of endpoint
         if card1_text:
@@ -408,7 +409,7 @@ def _draw_relationship(
         if start_row == end_row:
             # Horizontal: label below the line, centered
             mid_c = (start_col + end_col) // 2
-            label_col = mid_c - len(rel.label) // 2
+            label_col = mid_c - display_width(rel.label) // 2
             canvas.put_text(start_row + 1, label_col, rel.label, style="edge_label")
         elif start_col == end_col:
             # Straight vertical: label to the right of midpoint
@@ -420,7 +421,7 @@ def _draw_relationship(
             if use_horizontal:
                 # Label below the horizontal bend
                 label_r = mid_r + 1
-                label_c = (start_col + end_col) // 2 - len(rel.label) // 2
+                label_c = (start_col + end_col) // 2 - display_width(rel.label) // 2
                 canvas.put_text(label_r, label_c, rel.label, style="edge_label")
             else:
                 # Label to the right of first vertical segment (near source)
@@ -474,7 +475,7 @@ def render_er_diagram(diagram: ERDiagram, *, use_ascii: bool = False, padding_x:
         tw, _ = sizes[rel.entity2]
         mid_c = (sx + sw // 2 + tx + tw // 2) // 2
         if rel.label:
-            label_end = mid_c + 2 + len(rel.label)
+            label_end = mid_c + 2 + display_width(rel.label)
             width = max(width, label_end + _MARGIN)
         # Cardinality text at endpoints
         for card in (rel.card1, rel.card2):

--- a/src/termaid/renderer/gitgraph.py
+++ b/src/termaid/renderer/gitgraph.py
@@ -54,12 +54,19 @@ def _sort_branches(diagram: GitGraph) -> list[str]:
     return [name for _, _, name in ordered]
 
 
-def _commit_footprint(c: Commit) -> int:
-    """Return the half-width of the widest label (id or tag) for a commit."""
+def _commit_footprint(c: Commit, use_ascii: bool = False) -> int:
+    """Return the half-width of the widest label (id or tag) for a commit.
+
+    Accounts for the commit marker's display width so that adjacent
+    markers don't overlap in CJK mode where ● is 2 columns.
+    """
     w = display_width(c.id)
     if c.tag:
         w = max(w, display_width(c.tag) + 2)  # "[tag]"
-    return (w + 1) // 2  # ceil half
+    # Ensure the footprint is at least half the marker's display width
+    marker = _get_marker(c.type, use_ascii)
+    mw = char_width(marker)
+    return max((w + 1) // 2, (mw + 1) // 2)
 
 
 def _compute_branch_extents_lr(
@@ -129,21 +136,23 @@ def _compute_layout_lr(
 
     if commits:
         # First commit: place at left_offset + its own half-width
-        fp0 = _commit_footprint(commits[0])
+        fp0 = _commit_footprint(commits[0], use_ascii)
         commit_col[commits[0].id] = left_offset + fp0
 
         for i in range(1, len(commits)):
             prev = commits[i - 1]
             curr = commits[i]
-            prev_fp = _commit_footprint(prev)
-            curr_fp = _commit_footprint(curr)
-            # Minimum gap so labels don't overlap
-            label_gap = prev_fp + _LABEL_PAD + curr_fp
-            gap = max(_MIN_COMMIT_GAP, label_gap)
+            prev_fp = _commit_footprint(prev, use_ascii)
+            curr_fp = _commit_footprint(curr, use_ascii)
+            # Minimum gap so labels don't overlap.
+            # Account for wide commit markers (CJK mode: ● = 2 cols)
+            marker_extra = char_width(_get_marker("NORMAL", use_ascii)) - 1
+            label_gap = prev_fp + _LABEL_PAD + curr_fp + marker_extra
+            gap = max(_MIN_COMMIT_GAP + marker_extra, label_gap)
             commit_col[curr.id] = commit_col[prev.id] + gap
 
     last_col = max(commit_col.values(), default=left_offset)
-    last_fp = _commit_footprint(commits[-1]) if commits else 0
+    last_fp = _commit_footprint(commits[-1], use_ascii) if commits else 0
     canvas_width = last_col + last_fp + _MARGIN + 1
     canvas_height = _MARGIN + len(sorted_branches) * row_height + _MARGIN
 

--- a/src/termaid/renderer/gitgraph.py
+++ b/src/termaid/renderer/gitgraph.py
@@ -223,6 +223,18 @@ def _draw_lr(
             for r in range(r_min, r_max + 1):
                 canvas.put(r, col, v_char, style="edge")
 
+    # Build a set of columns occupied by vertical merge/fork lines
+    # so labels can avoid overlapping them.
+    merge_cols: set[int] = set()
+    for c in diagram.commits:
+        col = commit_col[c.id]
+        for parent_id in c.parents:
+            if parent_id not in commit_map:
+                continue
+            parent = commit_map[parent_id]
+            if parent.branch != c.branch:
+                merge_cols.add(col)
+
     # 4. Draw commit markers and labels (LAST so they are visible)
     for c in diagram.commits:
         col = commit_col[c.id]
@@ -232,10 +244,14 @@ def _draw_lr(
 
         canvas.put(row, col, marker, merge=False, style="node")
 
-        # Center label under the marker's visual midpoint
+        # Center label under the marker's visual midpoint.
+        # If the label would land on or immediately after a merge vertical
+        # line (which occupies the col below ┼), nudge it right.
         label = c.id
         visual_center = col + mw // 2
         label_col = visual_center - display_width(label) // 2
+        if col in merge_cols and label_col <= col + 1 and mw > 1:
+            label_col = col + 2
         canvas.put_text(row + 1, label_col, label, style="label")
 
         if c.tag:

--- a/src/termaid/renderer/gitgraph.py
+++ b/src/termaid/renderer/gitgraph.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from ..model.gitgraph import Commit, GitGraph
 from .canvas import Canvas
 from .charset import ASCII, UNICODE, CharSet
+from .textwidth import display_width
 
 # ── layout constants ──────────────────────────────────────────────
 _MIN_COMMIT_GAP = 6  # minimum horizontal gap between commit markers
@@ -57,7 +58,7 @@ def _commit_footprint(c: Commit) -> int:
     """Return the half-width of the widest label (id or tag) for a commit."""
     w = len(c.id)
     if c.tag:
-        w = max(w, len(c.tag) + 2)  # "[tag]"
+        w = max(w, display_width(c.tag) + 2)  # "[tag]"
     return (w + 1) // 2  # ceil half
 
 
@@ -118,7 +119,7 @@ def _compute_layout_lr(
 
     branch_label_width = 0
     for name in sorted_branches:
-        branch_label_width = max(branch_label_width, len(name))
+        branch_label_width = max(branch_label_width, display_width(name))
     left_offset = _MARGIN + branch_label_width + 2
 
     # Adaptive per-commit column placement:
@@ -170,7 +171,7 @@ def _draw_lr(
 
     commit_map: dict[str, Commit] = {c.id: c for c in diagram.commits}
 
-    branch_label_width = max((len(b) for b in sorted_branches), default=0)
+    branch_label_width = max((display_width(b) for b in sorted_branches), default=0)
     line_start_col = _MARGIN + branch_label_width + 1
 
     # Compute branch line extents (with merge/fork extensions)
@@ -222,12 +223,12 @@ def _draw_lr(
         canvas.put(row, col, marker, merge=False, style="node")
 
         label = c.id
-        label_col = col - len(label) // 2
+        label_col = col - display_width(label) // 2
         canvas.put_text(row + 1, label_col, label, style="label")
 
         if c.tag:
             tag_text = f"[{c.tag}]"
-            tag_col = col - len(tag_text) // 2
+            tag_col = col - display_width(tag_text) // 2
             canvas.put_text(row - 1, tag_col, tag_text, style="edge_label")
 
 
@@ -255,11 +256,11 @@ def _draw_tb(
     # Compute column gap based on max label width
     max_label = 0
     for b in sorted_branches:
-        max_label = max(max_label, len(b))
+        max_label = max(max_label, display_width(b))
     for c in diagram.commits:
         max_label = max(max_label, len(c.id))
         if c.tag:
-            max_label = max(max_label, len(c.tag) + 2)
+            max_label = max(max_label, display_width(c.tag) + 2)
 
     col_gap = max(max_label + 4, 10)
 
@@ -331,7 +332,7 @@ def _draw_tb(
         label_row = _MARGIN
     for name in sorted_branches:
         col = branch_col[name]
-        label_col = col - len(name) // 2
+        label_col = col - display_width(name) // 2
         canvas.put_text(label_row, label_col, name, style="subgraph")
 
     # 2. Draw branch lines (vertical)
@@ -372,18 +373,18 @@ def _draw_tb(
 
         canvas.put(row, col, marker, merge=False, style="node")
 
-        label_col = col - len(c.id) // 2
+        label_col = col - display_width(c.id) // 2
         if bottom_to_top:
             canvas.put_text(row - 1, label_col, c.id, style="label")
             if c.tag:
                 tag_text = f"[{c.tag}]"
-                tag_col = col - len(tag_text) // 2
+                tag_col = col - display_width(tag_text) // 2
                 canvas.put_text(row + 1, tag_col, tag_text, style="edge_label")
         else:
             canvas.put_text(row + 1, label_col, c.id, style="label")
             if c.tag:
                 tag_text = f"[{c.tag}]"
-                tag_col = col - len(tag_text) // 2
+                tag_col = col - display_width(tag_text) // 2
                 canvas.put_text(row - 1, tag_col, tag_text, style="edge_label")
 
 

--- a/src/termaid/renderer/gitgraph.py
+++ b/src/termaid/renderer/gitgraph.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from ..model.gitgraph import Commit, GitGraph
 from .canvas import Canvas
 from .charset import ASCII, UNICODE, CharSet
-from .textwidth import display_width
+from .textwidth import char_width, display_width
 
 # ── layout constants ──────────────────────────────────────────────
 _MIN_COMMIT_GAP = 6  # minimum horizontal gap between commit markers
@@ -219,16 +219,19 @@ def _draw_lr(
         col = commit_col[c.id]
         row = branch_row[c.branch]
         marker = _get_marker(c.type, use_ascii)
+        mw = char_width(marker)
 
         canvas.put(row, col, marker, merge=False, style="node")
 
+        # Center label under the marker's visual midpoint
         label = c.id
-        label_col = col - display_width(label) // 2
+        visual_center = col + mw // 2
+        label_col = visual_center - display_width(label) // 2
         canvas.put_text(row + 1, label_col, label, style="label")
 
         if c.tag:
             tag_text = f"[{c.tag}]"
-            tag_col = col - display_width(tag_text) // 2
+            tag_col = visual_center - display_width(tag_text) // 2
             canvas.put_text(row - 1, tag_col, tag_text, style="edge_label")
 
 
@@ -370,21 +373,23 @@ def _draw_tb(
         row = commit_row[c.id]
         col = branch_col[c.branch]
         marker = _get_marker(c.type, use_ascii)
+        mw = char_width(marker)
 
         canvas.put(row, col, marker, merge=False, style="node")
 
-        label_col = col - display_width(c.id) // 2
+        visual_center = col + mw // 2
+        label_col = visual_center - display_width(c.id) // 2
         if bottom_to_top:
             canvas.put_text(row - 1, label_col, c.id, style="label")
             if c.tag:
                 tag_text = f"[{c.tag}]"
-                tag_col = col - display_width(tag_text) // 2
+                tag_col = visual_center - display_width(tag_text) // 2
                 canvas.put_text(row + 1, tag_col, tag_text, style="edge_label")
         else:
             canvas.put_text(row + 1, label_col, c.id, style="label")
             if c.tag:
                 tag_text = f"[{c.tag}]"
-                tag_col = col - display_width(tag_text) // 2
+                tag_col = visual_center - display_width(tag_text) // 2
                 canvas.put_text(row - 1, tag_col, tag_text, style="edge_label")
 
 

--- a/src/termaid/renderer/gitgraph.py
+++ b/src/termaid/renderer/gitgraph.py
@@ -56,7 +56,7 @@ def _sort_branches(diagram: GitGraph) -> list[str]:
 
 def _commit_footprint(c: Commit) -> int:
     """Return the half-width of the widest label (id or tag) for a commit."""
-    w = len(c.id)
+    w = display_width(c.id)
     if c.tag:
         w = max(w, display_width(c.tag) + 2)  # "[tag]"
     return (w + 1) // 2  # ceil half
@@ -258,7 +258,7 @@ def _draw_tb(
     for b in sorted_branches:
         max_label = max(max_label, display_width(b))
     for c in diagram.commits:
-        max_label = max(max_label, len(c.id))
+        max_label = max(max_label, display_width(c.id))
         if c.tag:
             max_label = max(max_label, display_width(c.tag) + 2)
 

--- a/src/termaid/renderer/mindmap.py
+++ b/src/termaid/renderer/mindmap.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 
 from ..model.mindmap import Mindmap, MindmapNode
 from .canvas import Canvas
+from .textwidth import display_ljust, display_rjust, display_width
 
 # When root has more children than this, spill some to the left
 _OVERFLOW_THRESHOLD = 6
@@ -75,7 +76,7 @@ def render_mindmap(
         else:
             lines = _render_both_sides(root.label, left_children, right_children, ch)
 
-    width = max((len(line) for line in lines), default=1)
+    width = max((display_width(line) for line in lines), default=1)
     height = len(lines)
     canvas = Canvas(width + 1, height)
     for r, line in enumerate(lines):
@@ -109,7 +110,7 @@ def _render_subtree_right(node: MindmapNode, ch: _Chars) -> tuple[list[str], int
     child_block, child_conn = _stack_right(node.children, ch)
 
     connector = node.label + " " + ch.h + ch.h
-    pad = " " * len(connector)
+    pad = " " * display_width(connector)
     result: list[str] = []
     for i, line in enumerate(child_block):
         if i == child_conn:
@@ -183,11 +184,11 @@ def _render_subtree_left(node: MindmapNode, ch: _Chars) -> tuple[list[str], int]
         return [node.label], 0
 
     child_block, child_conn = _stack_left(node.children, ch)
-    child_width = max(len(line) for line in child_block)
-    child_block = [line.rjust(child_width) for line in child_block]
+    child_width = max(display_width(line) for line in child_block)
+    child_block = [display_rjust(line, child_width) for line in child_block]
 
     connector = ch.h + ch.h + " " + node.label
-    pad = " " * len(connector)
+    pad = " " * display_width(connector)
     result: list[str] = []
     for i, line in enumerate(child_block):
         if i == child_conn:
@@ -201,20 +202,20 @@ def _stack_left(children: list[MindmapNode], ch: _Chars) -> tuple[list[str], int
     """Stack child subtrees with branch chars on the right (mirrored)."""
     if len(children) == 1:
         sub, sc = _render_subtree_left(children[0], ch)
-        w = max(len(line) for line in sub)
+        w = max(display_width(line) for line in sub)
         result = []
         for i, line in enumerate(sub):
             if i == sc:
-                result.append(line.rjust(w) + " " + ch.h + ch.h)
+                result.append(display_rjust(line, w) + " " + ch.h + ch.h)
             else:
-                result.append(line.rjust(w) + "   ")
+                result.append(display_rjust(line, w) + "   ")
         return result, sc
 
     blocks: list[tuple[list[str], int]] = []
     for child in children:
         blocks.append(_render_subtree_left(child, ch))
 
-    max_w = max(max(len(line) for line in block) for block, _ in blocks)
+    max_w = max(max(display_width(line) for line in block) for block, _ in blocks)
     result: list[str] = []
     conn_rows: list[int] = []
 
@@ -224,7 +225,7 @@ def _stack_left(children: list[MindmapNode], ch: _Chars) -> tuple[list[str], int
         base = len(result)
 
         for li, line in enumerate(block):
-            padded = line.rjust(max_w)
+            padded = display_rjust(line, max_w)
             if li == bc:
                 conn_rows.append(base + li)
                 if is_first:
@@ -270,7 +271,7 @@ def _render_both_sides(
     right_block, _ = _stack_right(right_children, ch)
     left_block, _ = _stack_left(left_children, ch)
 
-    left_width = max((len(line) for line in left_block), default=0)
+    left_width = max((display_width(line) for line in left_block), default=0)
     rh = len(right_block)
     lh = len(left_block)
     total = max(rh, lh)
@@ -280,12 +281,12 @@ def _render_both_sides(
     root_row = total // 2
 
     root_part = ch.h + ch.h + " " + root_label + " " + ch.h + ch.h
-    pad = " " * len(root_part)
+    pad = " " * display_width(root_part)
 
     result: list[str] = []
     for row in range(total):
         li = row - l_off
-        left = left_block[li].ljust(left_width) if 0 <= li < lh else " " * left_width
+        left = display_ljust(left_block[li], left_width) if 0 <= li < lh else " " * left_width
         ri = row - r_off
         right = right_block[ri] if 0 <= ri < rh else ""
         center = root_part if row == root_row else pad

--- a/src/termaid/renderer/piechart.py
+++ b/src/termaid/renderer/piechart.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from ..model.piechart import PieChart
 from .canvas import Canvas
 from .charset import ASCII, UNICODE, CharSet
+from .textwidth import display_width
 
 _FILL_CHARS = ["█", "▓", "░", "▒", "▞", "▚", "▖", "▗"]
 _FILL_CHARS_ASCII = ["#", "*", "+", "~", ":", ".", "o", "="]
@@ -31,7 +32,7 @@ def render_pie_chart(
     fills = _FILL_CHARS_ASCII if use_ascii else _FILL_CHARS
 
     # Compute label column width
-    max_label_len = max(len(s.label) for s in diagram.slices)
+    max_label_len = max(display_width(s.label) for s in diagram.slices)
     label_col_w = max_label_len + _MARGIN
 
     # Compute suffix (percentage + optional value)
@@ -42,7 +43,7 @@ def render_pie_chart(
             suffixes.append(f" {pct:5.1f}%  [{s.value:g}]")
         else:
             suffixes.append(f" {pct:5.1f}%")
-    max_suffix_len = max(len(sf) for sf in suffixes)
+    max_suffix_len = max(display_width(sf) for sf in suffixes)
 
     bar_left = label_col_w
     canvas_w = bar_left + _BAR_WIDTH + max_suffix_len + _MARGIN
@@ -55,7 +56,7 @@ def render_pie_chart(
 
     # Title
     if diagram.title:
-        title_col = max(0, (canvas_w - len(diagram.title)) // 2)
+        title_col = max(0, (canvas_w - display_width(diagram.title)) // 2)
         canvas.put_text(_MARGIN, title_col, diagram.title, style="label")
 
     # ── Per-slice bars ────────────────────────────────────────────────────
@@ -65,8 +66,9 @@ def render_pie_chart(
         fill = fills[i % len(fills)]
         bar_len = max(1, round(s.value / total * _BAR_WIDTH))
 
-        # Label (right-aligned)
-        label_text = s.label.rjust(max_label_len)
+        # Label (right-aligned by display width)
+        pad = max_label_len - display_width(s.label)
+        label_text = " " * pad + s.label
         canvas.put_text(row, _MARGIN, label_text, style="label")
 
         # Bar

--- a/src/termaid/renderer/sequence.py
+++ b/src/termaid/renderer/sequence.py
@@ -9,6 +9,7 @@ from ..model.sequence import ActivateEvent, Block, BlockSection, DestroyEvent, M
 from .canvas import Canvas
 from .charset import ASCII, UNICODE, CharSet
 from .shapes import draw_rectangle, draw_cylinder
+from .textwidth import display_width
 
 
 # ── layout constants ──────────────────────────────────────────────
@@ -112,7 +113,7 @@ def _compute_layout(
         return [], [], 0, 0, 0, []
 
     # Box widths based on label length
-    box_widths = [max(len(p.label) + padding_x, 12) for p in diagram.participants]
+    box_widths = [max(display_width(p.label) + padding_x, 12) for p in diagram.participants]
 
     # Header height: tallest participant kind
     header_height = max(_KIND_HEIGHT.get(p.kind, 3) for p in diagram.participants)
@@ -158,7 +159,7 @@ def _compute_layout(
         if isinstance(ev, Note):
             # Notes may need gap expansion
             lines = _note_lines(ev)
-            note_width = max(len(line) for line in lines) + 4
+            note_width = max(display_width(line) for line in lines) + 4
             for pid in ev.participants:
                 pi = _participant_index(diagram, pid)
                 if pi < 0:
@@ -187,7 +188,7 @@ def _compute_layout(
         if si < 0 or ti < 0 or si == ti:
             continue
         lo, hi = min(si, ti), max(si, ti)
-        label_need = len(eff) + 6  # padding for arrow + spacing
+        label_need = display_width(eff) + 6  # padding for arrow + spacing
         spans = hi - lo
         per_gap = (label_need + spans - 1) // spans
         for g in range(lo, hi):
@@ -206,7 +207,7 @@ def _compute_layout(
             si = _participant_index(diagram, ev.source)
             ti = _participant_index(diagram, ev.target)
             if si >= 0 and si == ti:
-                loop_width = max(len(ev.label) + 4, 8)
+                loop_width = max(display_width(ev.label) + 4, 8)
                 needed = col_centers[si] + loop_width + 1
                 max_right = max(max_right, needed)
         elif isinstance(ev, Note):
@@ -215,7 +216,7 @@ def _compute_layout(
                 pi = _participant_index(diagram, pid)
                 if pi >= 0 and ev.position == "rightof":
                     lines = _note_lines(ev)
-                    note_width = max(len(line) for line in lines) + 4
+                    note_width = max(display_width(line) for line in lines) + 4
                     needed = col_centers[pi] + 2 + note_width + 1
                     max_right = max(max_right, needed)
 
@@ -246,7 +247,7 @@ def _draw_actor(canvas: Canvas, cx: int, y: int, label: str, use_ascii: bool) ->
     canvas.put(y + 1, cx + 1, "\\", merge=False, style=style)
     canvas.put(y + 2, cx - 1, "/", merge=False, style=style)
     canvas.put(y + 2, cx + 1, "\\", merge=False, style=style)
-    label_col = cx - len(label) // 2
+    label_col = cx - display_width(label) // 2
     canvas.put_text(y + 4, label_col, label, style="label")
 
 
@@ -284,7 +285,7 @@ def _draw_queue(canvas: Canvas, cx: int, y: int, width: int, label: str, cs: Cha
             canvas.put(r, bx + width - 1, cs.vertical, style=style)
 
     # Label centered
-    label_col = bx + (width - len(label)) // 2
+    label_col = bx + (width - display_width(label)) // 2
     label_row = y + h // 2
     canvas.put_text(label_row, label_col, label, style="label")
 
@@ -315,7 +316,7 @@ def _draw_boundary(canvas: Canvas, cx: int, y: int, label: str, cs: CharSet, use
     canvas.put(y + 2, box_right, cs.bottom_right, style=style)
 
     # Label below
-    label_col = cx - len(label) // 2
+    label_col = cx - display_width(label) // 2
     canvas.put_text(y + 4, label_col, label, style="label")
 
 
@@ -337,7 +338,7 @@ def _draw_control(canvas: Canvas, cx: int, y: int, label: str, cs: CharSet, use_
     canvas.put(y + 2, cx + 1, cs.round_bottom_right if not use_ascii else cs.bottom_right, style=style)
 
     # Label below
-    label_col = cx - len(label) // 2
+    label_col = cx - display_width(label) // 2
     canvas.put_text(y + 4, label_col, label, style="label")
 
 
@@ -358,7 +359,7 @@ def _draw_entity(canvas: Canvas, cx: int, y: int, label: str, cs: CharSet, use_a
     canvas.put(y + 2, cx + 1, cs.horizontal, merge=False, style=style)
 
     # Label below
-    label_col = cx - len(label) // 2
+    label_col = cx - display_width(label) // 2
     canvas.put_text(y + 4, label_col, label, style="label")
 
 
@@ -403,7 +404,7 @@ def _draw_collections(canvas: Canvas, cx: int, y: int, width: int, label: str, c
     canvas.put(y + h - 1, bx + width - 1, cs.bottom_right, style=style)
 
     # Label centered in front rectangle
-    label_col = bx + (width - len(label)) // 2
+    label_col = bx + (width - display_width(label)) // 2
     label_row = y + 1 + (h - 1) // 2
     canvas.put_text(label_row, label_col, label, style="label")
 
@@ -691,7 +692,7 @@ def _draw_note(
 ) -> None:
     """Draw a note box at the given row."""
     lines = _note_lines(note)
-    note_width = max(len(line) for line in lines) + 4
+    note_width = max(display_width(line) for line in lines) + 4
     note_height = len(lines) + 2
 
     # Determine horizontal placement
@@ -817,7 +818,7 @@ def _draw_self_message(
     use_ascii: bool,
 ) -> None:
     """Draw a self-referencing message (loop to the right)."""
-    loop_width = max(len(display_label) + 4, 8)
+    loop_width = max(display_width(display_label) + 4, 8)
 
     if msg.line_type == "dotted":
         h_char = "." if use_ascii else "┄"

--- a/src/termaid/renderer/shapes/__init__.py
+++ b/src/termaid/renderer/shapes/__init__.py
@@ -9,7 +9,7 @@ from typing import Protocol
 
 from ..canvas import Canvas
 from ..charset import CharSet
-from ..textwidth import display_width
+from ..textwidth import char_width, display_width
 from ...graph.shapes import NodeShape
 
 
@@ -128,9 +128,9 @@ def draw_diamond(
         │         │
         └────◆────┘
     """
-    cx = x + width // 2
     is_unicode = cs.horizontal == "─"
     marker = "◇" if is_unicode else "*"
+    cx = x + (width - char_width(marker)) // 2
 
     # Top border with ◆ at center
     canvas.put(y, x, cs.top_left, style=style)
@@ -192,9 +192,9 @@ def draw_circle(
         │         │
         ╰────◯────╯
     """
-    cx = x + width // 2
     is_unicode = cs.horizontal == "─"
     marker = "◯" if is_unicode else "O"
+    cx = x + (width - char_width(marker)) // 2
 
     # Draw as rounded box first
     draw_rounded(canvas, x, y, width, height, label, cs, style=style)
@@ -409,9 +409,10 @@ def draw_start_state(
     label: str, cs: CharSet, style: str = "",
 ) -> None:
     """Draw a start state: filled circle (●)."""
+    marker = "●" if cs.horizontal == "─" else "*"
     cy = y + height // 2
-    cx = x + width // 2
-    canvas.put(cy, cx, "●" if cs.horizontal == "─" else "*", style=style)
+    cx = x + (width - char_width(marker)) // 2
+    canvas.put(cy, cx, marker, style=style)
 
 
 def draw_end_state(
@@ -419,9 +420,10 @@ def draw_end_state(
     label: str, cs: CharSet, style: str = "",
 ) -> None:
     """Draw an end state: bullseye (◉)."""
+    marker = "◉" if cs.horizontal == "─" else "@"
     cy = y + height // 2
-    cx = x + width // 2
-    canvas.put(cy, cx, "◉" if cs.horizontal == "─" else "@", style=style)
+    cx = x + (width - char_width(marker)) // 2
+    canvas.put(cy, cx, marker, style=style)
 
 
 def draw_fork_join(

--- a/src/termaid/renderer/shapes/__init__.py
+++ b/src/termaid/renderer/shapes/__init__.py
@@ -130,7 +130,8 @@ def draw_diamond(
     """
     is_unicode = cs.horizontal == "─"
     marker = "◇" if is_unicode else "*"
-    cx = x + (width - char_width(marker)) // 2
+    mw = char_width(marker)
+    cx = x + (width - mw) // 2 if mw > 1 else x + width // 2
 
     # Top border with ◆ at center
     canvas.put(y, x, cs.top_left, style=style)
@@ -194,7 +195,8 @@ def draw_circle(
     """
     is_unicode = cs.horizontal == "─"
     marker = "◯" if is_unicode else "O"
-    cx = x + (width - char_width(marker)) // 2
+    mw = char_width(marker)
+    cx = x + (width - mw) // 2 if mw > 1 else x + width // 2
 
     # Draw as rounded box first
     draw_rounded(canvas, x, y, width, height, label, cs, style=style)
@@ -410,8 +412,9 @@ def draw_start_state(
 ) -> None:
     """Draw a start state: filled circle (●)."""
     marker = "●" if cs.horizontal == "─" else "*"
+    mw = char_width(marker)
     cy = y + height // 2
-    cx = x + (width - char_width(marker)) // 2
+    cx = x + (width - mw) // 2 if mw > 1 else x + width // 2
     canvas.put(cy, cx, marker, style=style)
 
 
@@ -421,8 +424,9 @@ def draw_end_state(
 ) -> None:
     """Draw an end state: bullseye (◉)."""
     marker = "◉" if cs.horizontal == "─" else "@"
+    mw = char_width(marker)
     cy = y + height // 2
-    cx = x + (width - char_width(marker)) // 2
+    cx = x + (width - mw) // 2 if mw > 1 else x + width // 2
     canvas.put(cy, cx, marker, style=style)
 
 

--- a/src/termaid/renderer/shapes/__init__.py
+++ b/src/termaid/renderer/shapes/__init__.py
@@ -9,6 +9,7 @@ from typing import Protocol
 
 from ..canvas import Canvas
 from ..charset import CharSet
+from ..textwidth import display_width
 from ...graph.shapes import NodeShape
 
 
@@ -398,7 +399,7 @@ def _draw_label(
     start_row = y + (height - len(lines)) // 2
     for i, line in enumerate(lines):
         row = start_row + i
-        col = x + (width - len(line)) // 2
+        col = x + (width - display_width(line)) // 2
         if 0 <= row < canvas.height:
             canvas.put_text(row, col, line, style=label_style)
 

--- a/src/termaid/renderer/textwidth.py
+++ b/src/termaid/renderer/textwidth.py
@@ -139,6 +139,8 @@ def display_ljust(text: str, width: int) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Auto-detect on import
+# Default: OFF.  CJK-ambiguous marker width varies across terminal fonts
+# even on CJK systems, so auto-detection is unreliable.  Users who need
+# wide markers should opt in via ``--cjk`` or ``TERMAID_CJK=1``.
 # ---------------------------------------------------------------------------
-_cjk_mode = _detect_cjk()
+_cjk_mode = _detect_cjk() if os.environ.get("TERMAID_CJK") else False

--- a/src/termaid/renderer/textwidth.py
+++ b/src/termaid/renderer/textwidth.py
@@ -32,15 +32,18 @@ import unicodedata
 # are intentionally excluded — they stay 1 column everywhere.
 # ---------------------------------------------------------------------------
 _CJK_WIDE_AMBIGUOUS: set[str] = set(
-    # Geometric Shapes (U+25A0–25FF) used as border markers
+    # Geometric Shapes used as border markers (inside box outlines).
+    # These MUST be 2-column in CJK mode so borders align with body rows.
     "◇◆●○◯"
-    "▲△▼▽"
     "■□▪▫"
-    # Miscellaneous Symbols used as markers
+    # Note: ▲▼△▽ (directional arrows / inheritance triangles) are
+    # intentionally excluded.  They are standalone markers placed at
+    # edge endpoints, and treating them as 2 columns causes adjacent
+    # markers (e.g. class diagram inheritance △△) to overlap.
+    # Note: Block Elements (█▓▒ etc.) are also excluded — they are
+    # bar-chart fill characters that must stay 1-column.
+    # Miscellaneous Symbols
     "✖"
-    # Note: Block Elements (█▓▒ etc.) are intentionally excluded.
-    # They are used as bar-chart fill characters and should remain
-    # 1-column in the grid to preserve bar proportions.
 )
 
 # Characters that have EAW=N (Narrow) but render as 2 columns in CJK

--- a/src/termaid/renderer/textwidth.py
+++ b/src/termaid/renderer/textwidth.py
@@ -1,0 +1,41 @@
+"""Unicode-aware text width utilities for terminal rendering.
+
+CJK (Chinese, Japanese, Korean) and other full-width characters occupy
+2 terminal columns, while most Latin/ASCII characters occupy 1.
+This module provides functions to compute display width correctly,
+replacing naive ``len()`` calls throughout the rendering pipeline.
+
+Uses only the standard library (``unicodedata``), keeping termaid's
+zero-runtime-dependency guarantee.
+"""
+from __future__ import annotations
+
+import unicodedata
+
+
+def char_width(ch: str) -> int:
+    """Return the display width of a single character in terminal columns.
+
+    Full-width (F) and wide (W) characters return 2; all others return 1.
+    """
+    eaw = unicodedata.east_asian_width(ch)
+    if eaw in ("W", "F"):
+        return 2
+    return 1
+
+
+def display_width(text: str) -> int:
+    """Return the total display width of *text* in terminal columns."""
+    return sum(char_width(ch) for ch in text)
+
+
+def display_rjust(text: str, width: int) -> str:
+    """Right-justify *text* to *width* display columns."""
+    pad = width - display_width(text)
+    return " " * max(0, pad) + text
+
+
+def display_ljust(text: str, width: int) -> str:
+    """Left-justify *text* to *width* display columns."""
+    pad = width - display_width(text)
+    return text + " " * max(0, pad)

--- a/src/termaid/renderer/textwidth.py
+++ b/src/termaid/renderer/textwidth.py
@@ -33,7 +33,7 @@ import unicodedata
 # ---------------------------------------------------------------------------
 _CJK_WIDE_AMBIGUOUS: set[str] = set(
     # Geometric Shapes (U+25A0–25FF) used as border markers
-    "◇◆●○◯◉"
+    "◇◆●○◯"
     "▲△▼▽"
     "■□▪▫"
     # Miscellaneous Symbols used as markers
@@ -42,6 +42,11 @@ _CJK_WIDE_AMBIGUOUS: set[str] = set(
     # They are used as bar-chart fill characters and should remain
     # 1-column in the grid to preserve bar proportions.
 )
+
+# Characters that have EAW=N (Narrow) but render as 2 columns in CJK
+# terminals due to font choices.  Tracked separately because they are
+# NOT flagged by ``unicodedata.east_asian_width``.
+_CJK_WIDE_NARROW: set[str] = set("◉")
 
 # Module-level switch — set via ``set_cjk_mode()`` or auto-detected.
 _cjk_mode: bool = False
@@ -105,8 +110,11 @@ def char_width(ch: str) -> int:
     eaw = unicodedata.east_asian_width(ch)
     if eaw in ("W", "F"):
         return 2
-    if _cjk_mode and eaw == "A" and ch in _CJK_WIDE_AMBIGUOUS:
-        return 2
+    if _cjk_mode:
+        if eaw == "A" and ch in _CJK_WIDE_AMBIGUOUS:
+            return 2
+        if ch in _CJK_WIDE_NARROW:
+            return 2
     return 1
 
 

--- a/src/termaid/renderer/textwidth.py
+++ b/src/termaid/renderer/textwidth.py
@@ -7,19 +7,105 @@ replacing naive ``len()`` calls throughout the rendering pipeline.
 
 Uses only the standard library (``unicodedata``), keeping termaid's
 zero-runtime-dependency guarantee.
+
+CJK mode
+--------
+In CJK terminals (Korean, Chinese, Japanese locale), certain
+"East Asian Ambiguous" characters — geometric shapes like ``◇ ● ▲ ▼``
+and block elements like ``█ ▓ ▒`` — render as **2 columns**, while
+box-drawing characters (``─ │ ┌ ┐``) remain **1 column**.
+
+When CJK mode is enabled (auto-detected or via ``--cjk`` flag), these
+ambiguous geometric / block characters are counted as 2 columns so that
+diamond markers, state-diagram circles, and pie-chart bars stay aligned
+with surrounding box-drawing borders.
 """
 from __future__ import annotations
 
+import os
+import sys
 import unicodedata
 
+# ---------------------------------------------------------------------------
+# CJK-ambiguous characters that render as 2 columns in CJK terminals
+# but 1 column in Western terminals.  Box-drawing characters (U+2500–257F)
+# are intentionally excluded — they stay 1 column everywhere.
+# ---------------------------------------------------------------------------
+_CJK_WIDE_AMBIGUOUS: set[str] = set(
+    # Geometric Shapes (U+25A0–25FF) used as border markers
+    "◇◆●○◯◉"
+    "▲△▼▽"
+    "■□▪▫"
+    # Miscellaneous Symbols used as markers
+    "✖"
+    # Note: Block Elements (█▓▒ etc.) are intentionally excluded.
+    # They are used as bar-chart fill characters and should remain
+    # 1-column in the grid to preserve bar proportions.
+)
+
+# Module-level switch — set via ``set_cjk_mode()`` or auto-detected.
+_cjk_mode: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Auto-detection
+# ---------------------------------------------------------------------------
+
+def _detect_cjk() -> bool:
+    """Return True if the terminal is likely a CJK environment."""
+    # Explicit opt-in / opt-out via environment variable
+    env = os.environ.get("TERMAID_CJK", "").lower()
+    if env in ("1", "true", "yes"):
+        return True
+    if env in ("0", "false", "no"):
+        return False
+
+    # Windows: check console output code page
+    if sys.platform == "win32":
+        try:
+            import ctypes
+            cp = ctypes.windll.kernel32.GetConsoleOutputCP()
+            # 932=Japanese, 936=Simplified Chinese, 949=Korean, 950=Traditional Chinese
+            if cp in (932, 936, 949, 950):
+                return True
+        except Exception:
+            pass
+
+    # Unix: check LANG / LC_ALL / LC_CTYPE
+    for var in ("LC_ALL", "LC_CTYPE", "LANG"):
+        val = os.environ.get(var, "").lower()
+        if any(tag in val for tag in ("ja", "ko", "zh")):
+            return True
+
+    return False
+
+
+def set_cjk_mode(enabled: bool) -> None:
+    """Enable or disable CJK-ambiguous-width mode globally."""
+    global _cjk_mode
+    _cjk_mode = enabled
+
+
+def is_cjk_mode() -> bool:
+    """Return the current CJK mode setting."""
+    return _cjk_mode
+
+
+# ---------------------------------------------------------------------------
+# Width calculation
+# ---------------------------------------------------------------------------
 
 def char_width(ch: str) -> int:
     """Return the display width of a single character in terminal columns.
 
-    Full-width (F) and wide (W) characters return 2; all others return 1.
+    Full-width (F) and wide (W) characters always return 2.
+    In CJK mode, specific ambiguous geometric/block characters also return 2.
+    Everything else returns 1.
     """
     eaw = unicodedata.east_asian_width(ch)
     if eaw in ("W", "F"):
+        return 2
+    if _cjk_mode and eaw == "A" and ch in _CJK_WIDE_AMBIGUOUS:
         return 2
     return 1
 
@@ -39,3 +125,9 @@ def display_ljust(text: str, width: int) -> str:
     """Left-justify *text* to *width* display columns."""
     pad = width - display_width(text)
     return text + " " * max(0, pad)
+
+
+# ---------------------------------------------------------------------------
+# Auto-detect on import
+# ---------------------------------------------------------------------------
+_cjk_mode = _detect_cjk()

--- a/src/termaid/renderer/treemap.py
+++ b/src/termaid/renderer/treemap.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from ..model.treemap import Treemap, TreemapNode
 from .canvas import Canvas
 from .charset import ASCII, UNICODE, CharSet
+from .textwidth import display_width
 
 _MIN_BOX_W = 4
 _MIN_BOX_H = 3
@@ -67,7 +68,7 @@ def _compute_min_width(nodes: list[TreemapNode]) -> int:
             node_w = child_w + 2
         else:
             # borders (2) + label padding
-            label_w = len(node.label) + _LABEL_PAD
+            label_w = display_width(node.label) + _LABEL_PAD
             node_w = max(_MIN_BOX_W, label_w + 2)
         total += node_w
 
@@ -220,17 +221,17 @@ def _draw_node(
     # Label — centered on the first inner row
     label = node.label
     inner_w = w - 2
-    if len(label) > inner_w:
+    if display_width(label) > inner_w:
         label = label[:inner_w - 1] + "…" if inner_w > 1 else label[:inner_w]
-    label_col = x + 1 + max(0, (inner_w - len(label)) // 2)
+    label_col = x + 1 + max(0, (inner_w - display_width(label)) // 2)
     canvas.put_text(y + 1, label_col, label, style="label")
 
     # Value (for leaves only)
     if not node.children and node.value > 0 and h >= 4:
         val_str = f"{node.value:g}"
-        if len(val_str) > inner_w:
+        if display_width(val_str) > inner_w:
             val_str = val_str[:inner_w]
-        val_col = x + 1 + max(0, (inner_w - len(val_str)) // 2)
+        val_col = x + 1 + max(0, (inner_w - display_width(val_str)) // 2)
         canvas.put_text(y + 2, val_col, val_str, style="edge_label")
 
     # Recurse into children

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,0 +1,558 @@
+"""Internationalization tests: CJK and multi-script label support.
+
+Verifies that Korean, Chinese, Japanese, and accented-Latin labels
+render with correct alignment.  Wide (full-width) characters occupy
+two terminal columns, so boxes, centering, and padding must account
+for display width rather than character count.
+"""
+from __future__ import annotations
+
+import pytest
+
+from termaid import render
+from termaid.renderer.textwidth import display_width
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _box_lines(output: str, label: str) -> list[str]:
+    """Return all output lines that belong to the box containing *label*.
+
+    Walks outward from the label row, collecting consecutive lines that
+    start with a box-drawing or padding character at roughly the same
+    indentation.
+    """
+    lines = output.split("\n")
+    for i, line in enumerate(lines):
+        if label in line:
+            return lines
+    return lines
+
+
+def _assert_label_visible(output: str, label: str) -> None:
+    """Assert that *label* appears somewhere in the rendered output."""
+    assert label in output, (
+        f"Label {label!r} not found in output:\n{output}"
+    )
+
+
+def _assert_boxes_aligned(output: str) -> None:
+    """Assert that every box in *output* has consistent display width.
+
+    A box is detected by its top-left corner (``+`` or a box-drawing
+    character).  The top border row, body rows, and bottom border row
+    must all have the same display width from left border to right border.
+    """
+    lines = output.split("\n")
+    box_chars = set("┌┐└┘─│├┤╭╮╰╯+-|")
+
+    for i, line in enumerate(lines):
+        # Detect top-left of a box
+        stripped = line.lstrip()
+        if not stripped:
+            continue
+        first = stripped[0]
+        if first not in ("┌", "╭", "+"):
+            continue
+
+        indent = len(line) - len(stripped)
+        # Find the right border on this line
+        top_dw = display_width(line.rstrip())
+
+        # Check the next few lines that start at the same indent with │ or |
+        for j in range(i + 1, min(i + 20, len(lines))):
+            row = lines[j]
+            if len(row) <= indent:
+                break
+            ch = row[indent] if indent < len(row) else " "
+            if ch in ("│", "|", "(", "╰", "└", "+"):
+                row_dw = display_width(row.rstrip())
+                assert row_dw == top_dw, (
+                    f"Box width mismatch at line {j}: "
+                    f"display_width={row_dw}, expected={top_dw}\n"
+                    f"  top:  {lines[i]!r}\n"
+                    f"  body: {row!r}"
+                )
+            else:
+                break
+
+
+# =========================================================================
+# Korean (한국어)
+# =========================================================================
+
+class TestKoreanFlowchart:
+    def test_lr(self):
+        output = render("graph LR\n  A[시작] --> B[종료]")
+        _assert_label_visible(output, "시작")
+        _assert_label_visible(output, "종료")
+        _assert_boxes_aligned(output)
+
+    def test_td_with_decision(self):
+        output = render(
+            "graph TD\n"
+            "  A[시작] --> B{결정}\n"
+            "  B -->|예| C[처리]\n"
+            "  B -->|아니오| D[오류]\n"
+            "  C --> E[종료]\n"
+            "  D --> E"
+        )
+        for label in ["시작", "결정", "처리", "오류", "종료"]:
+            _assert_label_visible(output, label)
+        _assert_boxes_aligned(output)
+
+    def test_edge_labels(self):
+        output = render(
+            "graph LR\n"
+            "  A[입력] -->|데이터 전송| B[출력]"
+        )
+        _assert_label_visible(output, "입력")
+        _assert_label_visible(output, "출력")
+        _assert_label_visible(output, "데이터 전송")
+
+
+class TestKoreanSequence:
+    def test_basic(self):
+        output = render(
+            "sequenceDiagram\n"
+            "    클라이언트->>서버: 요청\n"
+            "    서버-->>클라이언트: 응답"
+        )
+        _assert_label_visible(output, "클라이언트")
+        _assert_label_visible(output, "서버")
+        _assert_label_visible(output, "요청")
+        _assert_label_visible(output, "응답")
+
+    def test_three_participants(self):
+        output = render(
+            "sequenceDiagram\n"
+            "    사용자->>인증서버: 로그인 요청\n"
+            "    인증서버->>데이터베이스: 사용자 조회\n"
+            "    데이터베이스-->>인증서버: 결과\n"
+            "    인증서버-->>사용자: 토큰 발급"
+        )
+        for label in ["사용자", "인증서버", "데이터베이스"]:
+            _assert_label_visible(output, label)
+
+
+class TestKoreanClassDiagram:
+    def test_inheritance(self):
+        output = render(
+            "classDiagram\n"
+            "    동물 <|-- 개\n"
+            "    동물 <|-- 고양이\n"
+            "    동물 : +String 이름\n"
+            "    동물 : +int 나이\n"
+            "    개 : +물어오기()\n"
+            "    고양이 : +골골대기()"
+        )
+        for label in ["동물", "개", "고양이"]:
+            _assert_label_visible(output, label)
+        _assert_label_visible(output, "이름")
+        _assert_label_visible(output, "물어오기()")
+
+
+class TestKoreanERDiagram:
+    def test_basic(self):
+        output = render(
+            "erDiagram\n"
+            "    고객 ||--o{ 주문 : 주문하다\n"
+            "    주문 ||--|{ 항목 : 포함하다"
+        )
+        for label in ["고객", "주문", "항목"]:
+            _assert_label_visible(output, label)
+
+
+class TestKoreanPieChart:
+    def test_labels_aligned(self):
+        output = render(
+            "pie title 언어별 점유율\n"
+            '    "파이썬" : 45\n'
+            '    "자바스크립트" : 30\n'
+            '    "고" : 15\n'
+            '    "러스트" : 10'
+        )
+        for label in ["파이썬", "자바스크립트", "고", "러스트"]:
+            _assert_label_visible(output, label)
+        # All bar separators (┃) should be at the same column
+        lines = [l for l in output.split("\n") if "┃" in l]
+        if lines:
+            positions = [display_width(l.split("┃")[0]) for l in lines]
+            assert len(set(positions)) == 1, (
+                f"Bar separators not aligned: positions={positions}"
+            )
+
+
+class TestKoreanMindmap:
+    def test_basic_tree(self):
+        output = render(
+            "mindmap\n"
+            "  root((프로젝트))\n"
+            "    설계\n"
+            "      와이어프레임\n"
+            "    개발\n"
+            "      프론트엔드\n"
+            "      백엔드"
+        )
+        for label in ["프로젝트", "설계", "개발", "프론트엔드"]:
+            _assert_label_visible(output, label)
+
+
+class TestKoreanStateDiagram:
+    def test_basic(self):
+        output = render(
+            "stateDiagram-v2\n"
+            "    [*] --> 대기\n"
+            "    대기 --> 처리중 : 제출\n"
+            "    처리중 --> 완료 : 성공\n"
+            "    완료 --> [*]"
+        )
+        for label in ["대기", "처리중", "완료"]:
+            _assert_label_visible(output, label)
+        _assert_boxes_aligned(output)
+
+
+# =========================================================================
+# Chinese (中文)
+# =========================================================================
+
+class TestChineseFlowchart:
+    def test_lr(self):
+        output = render("graph LR\n  A[开始] --> B[结束]")
+        _assert_label_visible(output, "开始")
+        _assert_label_visible(output, "结束")
+        _assert_boxes_aligned(output)
+
+    def test_td_with_decision(self):
+        output = render(
+            "graph TD\n"
+            "  A[开始] --> B{判断}\n"
+            "  B -->|是| C[处理]\n"
+            "  B -->|否| D[错误]\n"
+            "  C --> E[结束]"
+        )
+        for label in ["开始", "判断", "处理", "错误", "结束"]:
+            _assert_label_visible(output, label)
+        _assert_boxes_aligned(output)
+
+
+class TestChineseSequence:
+    def test_basic(self):
+        output = render(
+            "sequenceDiagram\n"
+            "    客户端->>服务器: 发送请求\n"
+            "    服务器-->>客户端: 返回响应"
+        )
+        _assert_label_visible(output, "客户端")
+        _assert_label_visible(output, "服务器")
+        _assert_label_visible(output, "发送请求")
+
+
+class TestChineseClassDiagram:
+    def test_basic(self):
+        output = render(
+            "classDiagram\n"
+            "    动物 <|-- 猫\n"
+            "    动物 <|-- 狗\n"
+            "    动物 : +String 名字\n"
+            "    动物 : +int 年龄\n"
+            "    猫 : +发出呼噜声()\n"
+            "    狗 : +摇尾巴()"
+        )
+        for label in ["动物", "猫", "狗"]:
+            _assert_label_visible(output, label)
+        _assert_label_visible(output, "名字")
+
+
+class TestChinesePieChart:
+    def test_aligned(self):
+        output = render(
+            "pie\n"
+            '    "Python" : 40\n'
+            '    "JavaScript" : 30\n'
+            '    "Go语言" : 20\n'
+            '    "Rust" : 10'
+        )
+        _assert_label_visible(output, "Go语言")
+        lines = [l for l in output.split("\n") if "┃" in l]
+        if lines:
+            positions = [display_width(l.split("┃")[0]) for l in lines]
+            assert len(set(positions)) == 1, (
+                f"Bar separators not aligned: positions={positions}"
+            )
+
+
+class TestChineseMindmap:
+    def test_basic(self):
+        output = render(
+            "mindmap\n"
+            "  root((项目))\n"
+            "    前端\n"
+            "      React\n"
+            "    后端\n"
+            "      Python\n"
+            "      数据库"
+        )
+        for label in ["项目", "前端", "后端", "数据库"]:
+            _assert_label_visible(output, label)
+
+
+# =========================================================================
+# Japanese (日本語)
+# =========================================================================
+
+class TestJapaneseFlowchart:
+    def test_lr(self):
+        output = render("graph LR\n  A[開始] --> B[終了]")
+        _assert_label_visible(output, "開始")
+        _assert_label_visible(output, "終了")
+        _assert_boxes_aligned(output)
+
+    def test_td_with_decision(self):
+        output = render(
+            "graph TD\n"
+            "  A[開始] --> B{判定}\n"
+            "  B -->|はい| C[処理]\n"
+            "  B -->|いいえ| D[エラー]\n"
+            "  C --> E[終了]"
+        )
+        for label in ["開始", "判定", "処理", "エラー", "終了"]:
+            _assert_label_visible(output, label)
+        _assert_boxes_aligned(output)
+
+
+class TestJapaneseSequence:
+    def test_basic(self):
+        output = render(
+            "sequenceDiagram\n"
+            "    クライアント->>サーバー: リクエスト送信\n"
+            "    サーバー-->>クライアント: レスポンス返却"
+        )
+        _assert_label_visible(output, "クライアント")
+        _assert_label_visible(output, "サーバー")
+        _assert_label_visible(output, "リクエスト送信")
+
+
+class TestJapaneseClassDiagram:
+    def test_basic(self):
+        output = render(
+            "classDiagram\n"
+            "    動物 <|-- 犬\n"
+            "    動物 <|-- 猫\n"
+            "    動物 : +String 名前\n"
+            "    動物 : +int 年齢\n"
+            "    犬 : +お座り()\n"
+            "    猫 : +ゴロゴロ()"
+        )
+        for label in ["動物", "犬", "猫"]:
+            _assert_label_visible(output, label)
+        _assert_label_visible(output, "名前")
+
+
+class TestJapanesePieChart:
+    def test_aligned(self):
+        output = render(
+            "pie\n"
+            '    "パイソン" : 45\n'
+            '    "ジャバスクリプト" : 30\n'
+            '    "ゴー" : 15\n'
+            '    "ラスト" : 10'
+        )
+        for label in ["パイソン", "ジャバスクリプト", "ゴー", "ラスト"]:
+            _assert_label_visible(output, label)
+        lines = [l for l in output.split("\n") if "┃" in l]
+        if lines:
+            positions = [display_width(l.split("┃")[0]) for l in lines]
+            assert len(set(positions)) == 1, (
+                f"Bar separators not aligned: positions={positions}"
+            )
+
+
+class TestJapaneseMindmap:
+    def test_basic(self):
+        output = render(
+            "mindmap\n"
+            "  root((プロジェクト))\n"
+            "    フロントエンド\n"
+            "      React\n"
+            "    バックエンド\n"
+            "      Python\n"
+            "      データベース"
+        )
+        for label in ["プロジェクト", "フロントエンド", "バックエンド"]:
+            _assert_label_visible(output, label)
+
+
+# =========================================================================
+# Spanish / accented Latin (Español)
+# =========================================================================
+
+class TestSpanishFlowchart:
+    def test_lr(self):
+        output = render("graph LR\n  A[Inicio] --> B[Decisión]")
+        _assert_label_visible(output, "Inicio")
+        _assert_label_visible(output, "Decisión")
+        _assert_boxes_aligned(output)
+
+    def test_td_with_accents(self):
+        output = render(
+            "graph TD\n"
+            "  A[Autenticación] --> B{Válido?}\n"
+            "  B -->|Sí| C[Autorización]\n"
+            "  B -->|No| D[Rechazo]\n"
+            "  C --> E[Conexión exitosa]"
+        )
+        for label in ["Autenticación", "Válido?", "Autorización", "Rechazo"]:
+            _assert_label_visible(output, label)
+        _assert_boxes_aligned(output)
+
+
+class TestSpanishSequence:
+    def test_basic(self):
+        output = render(
+            "sequenceDiagram\n"
+            "    Usuario->>Servidor: Solicitud de conexión\n"
+            "    Servidor-->>Usuario: Respuesta exitosa"
+        )
+        _assert_label_visible(output, "Usuario")
+        _assert_label_visible(output, "Servidor")
+        _assert_label_visible(output, "Solicitud de conexión")
+
+
+class TestSpanishPieChart:
+    def test_aligned(self):
+        output = render(
+            "pie title Distribución de lenguajes\n"
+            '    "Español" : 40\n'
+            '    "Inglés" : 35\n'
+            '    "Francés" : 25'
+        )
+        _assert_label_visible(output, "Español")
+        _assert_label_visible(output, "Inglés")
+        _assert_label_visible(output, "Francés")
+
+
+# =========================================================================
+# Mixed scripts (다국어 혼합)
+# =========================================================================
+
+class TestMixedScripts:
+    def test_english_korean_mix(self):
+        output = render(
+            "graph LR\n"
+            "  A[Login 화면] --> B[API 서버]\n"
+            "  B --> C[DB 조회]"
+        )
+        _assert_label_visible(output, "Login 화면")
+        _assert_label_visible(output, "API 서버")
+        _assert_boxes_aligned(output)
+
+    def test_cjk_mixed_flowchart(self):
+        output = render(
+            "graph TD\n"
+            "  A[開始 Start] --> B[처리 Process]\n"
+            "  B --> C[终了 End]"
+        )
+        _assert_label_visible(output, "開始 Start")
+        _assert_label_visible(output, "처리 Process")
+        _assert_boxes_aligned(output)
+
+    def test_mixed_sequence(self):
+        output = render(
+            "sequenceDiagram\n"
+            "    Frontend->>API서버: Request 요청\n"
+            "    API서버-->>Frontend: Response 응답"
+        )
+        _assert_label_visible(output, "Frontend")
+        _assert_label_visible(output, "API서버")
+
+    def test_mixed_pie(self):
+        output = render(
+            "pie\n"
+            '    "한국어 Korean" : 30\n'
+            '    "中文 Chinese" : 25\n'
+            '    "日本語 Japanese" : 25\n'
+            '    "English" : 20'
+        )
+        lines = [l for l in output.split("\n") if "┃" in l]
+        if lines:
+            positions = [display_width(l.split("┃")[0]) for l in lines]
+            assert len(set(positions)) == 1, (
+                f"Bar separators not aligned: positions={positions}"
+            )
+
+
+# =========================================================================
+# ASCII mode with CJK
+# =========================================================================
+
+class TestAsciiModeI18n:
+    def test_korean_ascii(self):
+        output = render(
+            "graph LR\n  A[시작] --> B[종료]",
+            use_ascii=True,
+        )
+        _assert_label_visible(output, "시작")
+        _assert_label_visible(output, "종료")
+        _assert_boxes_aligned(output)
+        # No unicode box-drawing
+        unicode_box = set("┌┐└┘─│├┤╭╮╰╯►◄▲▼")
+        for ch in output:
+            assert ch not in unicode_box, (
+                f"Unicode char {ch!r} in ASCII output"
+            )
+
+    def test_japanese_ascii(self):
+        output = render(
+            "graph LR\n  A[開始] --> B[終了]",
+            use_ascii=True,
+        )
+        _assert_label_visible(output, "開始")
+        _assert_label_visible(output, "終了")
+        _assert_boxes_aligned(output)
+
+
+# =========================================================================
+# display_width unit tests
+# =========================================================================
+
+class TestDisplayWidth:
+    """Unit tests for the textwidth module."""
+
+    def test_ascii(self):
+        assert display_width("Hello") == 5
+
+    def test_korean(self):
+        assert display_width("한글") == 4
+
+    def test_chinese(self):
+        assert display_width("中文") == 4
+
+    def test_japanese_katakana(self):
+        assert display_width("カタカナ") == 8
+
+    def test_japanese_hiragana(self):
+        assert display_width("ひらがな") == 8
+
+    def test_mixed(self):
+        assert display_width("ABC한글DEF") == 10
+
+    def test_empty(self):
+        assert display_width("") == 0
+
+    def test_accented_latin(self):
+        # Accented latin characters are narrow (1 column each)
+        assert display_width("café") == 4
+        assert display_width("Decisión") == 8
+
+    def test_fullwidth_latin(self):
+        # Fullwidth Latin letters are 2 columns each
+        assert display_width("\uff21\uff22\uff23") == 6  # ABC
+
+    def test_single_korean_char(self):
+        from termaid.renderer.textwidth import char_width
+        assert char_width("가") == 2
+        assert char_width("A") == 1
+        assert char_width(" ") == 1

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -518,6 +518,170 @@ class TestAsciiModeI18n:
 # display_width unit tests
 # =========================================================================
 
+# =========================================================================
+# Varied text lengths, mixed characters, odd/even special char counts
+# =========================================================================
+
+class TestVariedLabelLengths:
+    """Boxes must align regardless of label display width differences."""
+
+    def test_short_and_long_labels_td(self):
+        """Short (2 CJK = 4 cols) vs long (6 CJK = 12 cols) in same flow."""
+        output = render(
+            "graph TD\n"
+            "  A[가] --> B[데이터베이스]"
+        )
+        _assert_label_visible(output, "가")
+        _assert_label_visible(output, "데이터베이스")
+        _assert_boxes_aligned(output)
+
+    def test_single_char_labels(self):
+        output = render("graph LR\n  A[A] --> B[가]")
+        _assert_label_visible(output, "A")
+        _assert_label_visible(output, "가")
+        _assert_boxes_aligned(output)
+
+    def test_three_varying_widths_lr(self):
+        """Three nodes with display widths 2, 8, 12."""
+        output = render(
+            "graph LR\n"
+            "  A[가] --> B[API 서버] --> C[데이터베이스]"
+        )
+        _assert_boxes_aligned(output)
+
+    def test_three_varying_widths_td(self):
+        output = render(
+            "graph TD\n"
+            "  A[가] --> B[API 서버] --> C[데이터베이스]"
+        )
+        _assert_boxes_aligned(output)
+
+
+class TestMixedCharacterTypes:
+    """Labels with interleaved ASCII + CJK characters."""
+
+    def test_ascii_cjk_ascii(self):
+        output = render("graph LR\n  A[API서버v2]")
+        _assert_label_visible(output, "API서버v2")
+        _assert_boxes_aligned(output)
+
+    def test_cjk_ascii_cjk(self):
+        output = render("graph LR\n  A[서버API서버]")
+        _assert_label_visible(output, "서버API서버")
+        _assert_boxes_aligned(output)
+
+    def test_numbers_and_cjk(self):
+        output = render("graph LR\n  A[제품123호] --> B[버전4.0출시]")
+        _assert_label_visible(output, "제품123호")
+        _assert_label_visible(output, "버전4.0출시")
+        _assert_boxes_aligned(output)
+
+    def test_special_punctuation_and_cjk(self):
+        output = render('graph LR\n  A["사용자(관리자)"] --> B["서버[운영]"]')
+        _assert_label_visible(output, "사용자(관리자)")
+        _assert_label_visible(output, "서버[운영]")
+
+    def test_mixed_in_diamond(self):
+        """Diamond shape with mixed-width label."""
+        output = render(
+            "graph TD\n"
+            "  A[시작] --> B{유효한가?}\n"
+            "  B -->|예| C[완료]"
+        )
+        _assert_label_visible(output, "유효한가?")
+        _assert_boxes_aligned(output)
+
+    def test_mixed_in_sequence(self):
+        output = render(
+            "sequenceDiagram\n"
+            "    User->>API서버: POST /login\n"
+            "    API서버-->>User: 200 OK토큰발급"
+        )
+        _assert_label_visible(output, "API서버")
+        _assert_label_visible(output, "200 OK토큰발급")
+
+    def test_mixed_in_class(self):
+        output = render(
+            "classDiagram\n"
+            "    UserService <|-- AdminService\n"
+            "    UserService : +String 사용자명\n"
+            "    UserService : +login(비밀번호 str)"
+        )
+        _assert_label_visible(output, "사용자명")
+
+
+class TestOddEvenSpecialChars:
+    """Ensure alignment with odd and even counts of CJK characters."""
+
+    def test_one_cjk_char(self):
+        """1 CJK char (display width 2) — odd count."""
+        output = render("graph LR\n  A[가]")
+        _assert_label_visible(output, "가")
+        _assert_boxes_aligned(output)
+
+    def test_two_cjk_chars(self):
+        """2 CJK chars (display width 4) — even count."""
+        output = render("graph LR\n  A[가나]")
+        _assert_label_visible(output, "가나")
+        _assert_boxes_aligned(output)
+
+    def test_three_cjk_chars(self):
+        """3 CJK chars (display width 6) — odd count."""
+        output = render("graph LR\n  A[가나다]")
+        _assert_label_visible(output, "가나다")
+        _assert_boxes_aligned(output)
+
+    def test_odd_mixed(self):
+        """Odd total display width: 1 ASCII + 1 CJK = 3 cols."""
+        output = render("graph LR\n  A[A가]")
+        _assert_label_visible(output, "A가")
+        _assert_boxes_aligned(output)
+
+    def test_even_mixed(self):
+        """Even total display width: 2 ASCII + 1 CJK = 4 cols."""
+        output = render("graph LR\n  A[AB가]")
+        _assert_label_visible(output, "AB가")
+        _assert_boxes_aligned(output)
+
+    def test_odd_cjk_in_diamond(self):
+        """Diamond with odd CJK count."""
+        output = render("graph TD\n  A{가나다}")
+        _assert_label_visible(output, "가나다")
+        _assert_boxes_aligned(output)
+
+    def test_even_cjk_in_diamond(self):
+        """Diamond with even CJK count."""
+        output = render("graph TD\n  A{가나}")
+        _assert_label_visible(output, "가나")
+        _assert_boxes_aligned(output)
+
+    def test_pie_odd_even_labels(self):
+        """Pie chart with odd/even width labels must align bars."""
+        output = render(
+            "pie\n"
+            '    "가" : 40\n'
+            '    "가나" : 30\n'
+            '    "가나다" : 20\n'
+            '    "ABCD" : 10'
+        )
+        lines = [l for l in output.split("\n") if "┃" in l]
+        if lines:
+            positions = [display_width(l.split("┃")[0]) for l in lines]
+            assert len(set(positions)) == 1, (
+                f"Bar separators not aligned: positions={positions}"
+            )
+
+    def test_state_diagram_odd_cjk(self):
+        """State with odd CJK char label — check circle markers align."""
+        output = render(
+            "stateDiagram-v2\n"
+            "    [*] --> 가나다\n"
+            "    가나다 --> [*]"
+        )
+        _assert_label_visible(output, "가나다")
+        _assert_boxes_aligned(output)
+
+
 class TestDisplayWidth:
     """Unit tests for the textwidth module."""
 


### PR DESCRIPTION
Replace len() with display_width() across all renderers so that CJK (Korean, Chinese, Japanese) and other full-width characters correctly occupy 2 terminal columns.  Adds wide-character tracking in Canvas (continuation sentinel) and display-width-aware padding helpers.  Includes 42 i18n tests covering all 10 diagram types in four languages.

