### PR TITLE
fix: improve edge label rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,7 @@ packet
 | `--padding-x N` | Horizontal padding inside boxes (default: 4) |
 | `--padding-y N` | Vertical padding inside boxes (default: 2) |
 | `--gap N` | Space between nodes (default: 4). Use `1` or `2` for compact diagrams |
+| `--inline-edge-labels` | Attach flowchart labels directly to their edges |
 | `--width N` | Max output width. Re-renders with smaller gap/padding if exceeded |
 | `--no-auto-fit` | Disable automatic compaction when diagram exceeds terminal width |
 | `--sharp-edges` | Sharp corners on edge turns instead of rounded |

--- a/src/termaid/__init__.py
+++ b/src/termaid/__init__.py
@@ -43,6 +43,7 @@ def render(
     padding_y: int = 2,
     rounded_edges: bool = True,
     gap: int = 4,
+    inline_edge_labels: bool = False,
 ) -> str:
     """Render mermaid syntax as Unicode (or ASCII) art.
 
@@ -52,6 +53,7 @@ def render(
         padding_x: Horizontal padding inside node boxes
         padding_y: Vertical padding inside node boxes
         gap: Space between nodes (default: 4)
+        inline_edge_labels: Attach flowchart labels directly to their edges
 
     Returns:
         Rendered diagram as a string
@@ -171,7 +173,15 @@ def render(
 
     graph = parse(text)
     from .output.text import render_text
-    return render_text(graph, use_ascii=use_ascii, padding_x=padding_x, padding_y=padding_y, rounded_edges=rounded_edges, gap=gap)
+    return render_text(
+        graph,
+        use_ascii=use_ascii,
+        padding_x=padding_x,
+        padding_y=padding_y,
+        rounded_edges=rounded_edges,
+        gap=gap,
+        inline_edge_labels=inline_edge_labels,
+    )
 
 
 def render_rich(
@@ -183,6 +193,7 @@ def render_rich(
     rounded_edges: bool = True,
     theme: str = "default",
     gap: int = 4,
+    inline_edge_labels: bool = False,
 ):
     """Render mermaid syntax as a Rich Text object with colors.
 
@@ -195,6 +206,7 @@ def render_rich(
         padding_y: Vertical padding inside node boxes
         theme: Color theme name (default, terra, neon, mono, amber, phosphor)
         gap: Space between nodes (default: 4)
+        inline_edge_labels: Attach flowchart labels directly to their edges
 
     Returns:
         rich.text.Text object
@@ -334,7 +346,16 @@ def render_rich(
 
     graph = parse(text)
     from .output.rich import render_rich as _render_rich
-    return _render_rich(graph, use_ascii=use_ascii, padding_x=padding_x, padding_y=padding_y, rounded_edges=rounded_edges, theme=theme, gap=gap)
+    return _render_rich(
+        graph,
+        use_ascii=use_ascii,
+        padding_x=padding_x,
+        padding_y=padding_y,
+        rounded_edges=rounded_edges,
+        theme=theme,
+        gap=gap,
+        inline_edge_labels=inline_edge_labels,
+    )
 
 
 # Lazy import for MermaidWidget

--- a/src/termaid/cli.py
+++ b/src/termaid/cli.py
@@ -69,6 +69,7 @@ def _auto_fit(
             padding_y=args.padding_y,
             rounded_edges=not args.sharp_edges,
             gap=gap,
+            inline_edge_labels=args.inline_edge_labels,
         )
         if _max_line_width(_plain(candidate)) <= target_width:
             return candidate
@@ -178,6 +179,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Disable automatic compaction when diagram exceeds terminal width",
     )
     parser.add_argument(
+        "--inline-edge-labels",
+        action="store_true",
+        help="Attach labels directly to their edges",
+    )
+    parser.add_argument(
         "-o", "--output",
         default=None,
         metavar="FILE",
@@ -274,6 +280,7 @@ def main(argv: list[str] | None = None) -> int:
                 padding_y=args.padding_y,
                 rounded_edges=not args.sharp_edges,
                 gap=args.gap,
+                inline_edge_labels=args.inline_edge_labels,
             )
             rich_result = _auto_fit(
                 rich_result, render_source, args,
@@ -302,6 +309,7 @@ def main(argv: list[str] | None = None) -> int:
                 padding_y=args.padding_y,
                 rounded_edges=not args.sharp_edges,
                 gap=args.gap,
+                inline_edge_labels=args.inline_edge_labels,
             )
             result = _auto_fit(
                 result, render_source, args,

--- a/src/termaid/output/rich.py
+++ b/src/termaid/output/rich.py
@@ -60,6 +60,7 @@ def render_rich(
     rounded_edges: bool = True,
     theme: str = "default",
     gap: int = 4,
+    inline_edge_labels: bool = False,
 ) -> Text:
     """Render a graph as a Rich Text object with colors.
 
@@ -73,7 +74,15 @@ def render_rich(
             "Install it with: pip install termaid[rich]"
         )
 
-    canvas = render_graph_canvas(graph, use_ascii=use_ascii, padding_x=padding_x, padding_y=padding_y, rounded_edges=rounded_edges, gap=gap)
+    canvas = render_graph_canvas(
+        graph,
+        use_ascii=use_ascii,
+        padding_x=padding_x,
+        padding_y=padding_y,
+        rounded_edges=rounded_edges,
+        gap=gap,
+        inline_edge_labels=inline_edge_labels,
+    )
     if canvas is None:
         return Text("")
 

--- a/src/termaid/output/text.py
+++ b/src/termaid/output/text.py
@@ -12,6 +12,15 @@ def render_text(
     padding_y: int = 2,
     rounded_edges: bool = True,
     gap: int = 4,
+    inline_edge_labels: bool = False,
 ) -> str:
     """Render a graph to plain text."""
-    return render_graph(graph, use_ascii=use_ascii, padding_x=padding_x, padding_y=padding_y, rounded_edges=rounded_edges, gap=gap)
+    return render_graph(
+        graph,
+        use_ascii=use_ascii,
+        padding_x=padding_x,
+        padding_y=padding_y,
+        rounded_edges=rounded_edges,
+        gap=gap,
+        inline_edge_labels=inline_edge_labels,
+    )

--- a/src/termaid/renderer/canvas.py
+++ b/src/termaid/renderer/canvas.py
@@ -192,7 +192,14 @@ class Canvas:
         if style:
             self._style_grid[row][col] = style
 
-    def put_text(self, row: int, col: int, text: str, style: str = "") -> None:
+    def put_text(
+        self,
+        row: int,
+        col: int,
+        text: str,
+        style: str = "",
+        overwrite_spaces: bool = False,
+    ) -> None:
         """Place a string of characters starting at (row, col).
 
         Wide (CJK) characters advance the column by 2 and leave a
@@ -201,10 +208,22 @@ class Canvas:
         """
         offset = 0
         for ch in text:
-            self.put(row, col + offset, ch, merge=False, style=style)
+            target_col = col + offset
+            if (
+                ch == " "
+                and overwrite_spaces
+                and 0 <= row < self.height
+                and 0 <= target_col < self.width
+                and not self._protected[row][target_col]
+            ):
+                self._grid[row][target_col] = " "
+                self._directions[row][target_col] = 0
+                self._style_grid[row][target_col] = style or "default"
+            else:
+                self.put(row, target_col, ch, merge=False, style=style)
             if unicodedata.east_asian_width(ch) in ("F", "W"):
                 # Wide char occupies 2 columns; blank the shadow cell
-                self._blank_shadow_cell(row, col + offset + 1, style)
+                self._blank_shadow_cell(row, target_col + 1, style)
                 offset += 2
             else:
                 offset += 1

--- a/src/termaid/renderer/draw.py
+++ b/src/termaid/renderer/draw.py
@@ -482,25 +482,38 @@ def _label_overlaps(
     return False
 
 
-def _try_place_label(
+def _place_label(
     canvas: Canvas,
     row: int, col: int, label: str,
     placed: list[tuple[int, int, int]],
 ) -> bool:
-    """Try to place a label at (row, col). Returns True if placed."""
+    """Place a complete label when every character can be written."""
     col_end = col + display_width(label)
     if col < 0 or row < 0:
         return False
-    if _label_overlaps(row, col, col_end, placed):
-        return False
+    for target_col in range(col, col_end):
+        if canvas.is_protected(row, target_col) and canvas.get(row, target_col) != " ":
+            return False
     # Ensure canvas is large enough for the label
     needed_w = col_end + 1
     needed_h = row + 1
     if needed_w > canvas.width or needed_h > canvas.height:
         canvas.resize(max(canvas.width, needed_w), max(canvas.height, needed_h))
-    canvas.put_text(row, col, label, style="edge_label")
+    canvas.put_text(row, col, label, style="edge_label", overwrite_spaces=True)
     placed.append((row, col, col_end))
     return True
+
+
+def _try_place_label(
+    canvas: Canvas,
+    row: int, col: int, label: str,
+    placed: list[tuple[int, int, int]],
+) -> bool:
+    """Try to place a non-overlapping label at (row, col)."""
+    col_end = col + display_width(label)
+    if _label_overlaps(row, col, col_end, placed):
+        return False
+    return _place_label(canvas, row, col, label, placed)
 
 
 def _find_last_turn(path: list[tuple[int, int]]) -> int:
@@ -613,7 +626,6 @@ def _draw_edge_label(
     if not label:
         return
 
-    label_len = display_width(label)
     path = re.draw_path
 
     # Build segment list ordered by preference: post-turn segments first,
@@ -658,8 +670,7 @@ def _draw_edge_label(
     # Force place at midpoint of path
     mid_idx = len(path) // 2
     mx, my = path[mid_idx]
-    canvas.put_text(my - 1, mx + 1, label, style="edge_label")
-    placed_labels.append((my - 1, mx + 1, mx + 1 + label_len))
+    _place_label(canvas, my - 1, mx + 1, label, placed_labels)
 
 
 def _draw_notes(canvas: Canvas, graph: Graph, layout: GridLayout, cs: CharSet) -> None:

--- a/src/termaid/renderer/draw.py
+++ b/src/termaid/renderer/draw.py
@@ -29,6 +29,7 @@ def render_graph(
     padding_y: int = 2,
     rounded_edges: bool = True,
     gap: int = 4,
+    inline_edge_labels: bool = False,
 ) -> str:
     """Render a graph to a string.
 
@@ -39,6 +40,7 @@ def render_graph(
         padding_y: Vertical padding inside node boxes
         rounded_edges: Use rounded corners on edge turns (╭╮╰╯ vs ┌┐└┘)
         gap: Space between nodes (default: 4)
+        inline_edge_labels: Attach labels directly to their edge segments
 
     Returns:
         The rendered diagram as a string
@@ -46,6 +48,7 @@ def render_graph(
     canvas = render_graph_canvas(
         graph, use_ascii=use_ascii, padding_x=padding_x, padding_y=padding_y,
         rounded_edges=rounded_edges, gap=gap,
+        inline_edge_labels=inline_edge_labels,
     )
     if canvas is None:
         return ""
@@ -59,6 +62,7 @@ def render_graph_canvas(
     padding_y: int = 2,
     rounded_edges: bool = True,
     gap: int = 4,
+    inline_edge_labels: bool = False,
 ) -> Canvas | None:
     """Render a graph and return the Canvas (with style info).
 
@@ -104,7 +108,11 @@ def render_graph_canvas(
     _draw_nodes(canvas, graph, layout, cs)
 
     # 3. Draw edges
-    _draw_edges(canvas, graph, layout, routed, cs, rounded_edges=rounded_edges)
+    _draw_edges(
+        canvas, graph, layout, routed, cs,
+        rounded_edges=rounded_edges,
+        inline_edge_labels=inline_edge_labels,
+    )
 
     # 4. Draw subgraph labels (on top of everything else)
     _draw_subgraph_labels(canvas, layout, cs)
@@ -217,6 +225,7 @@ def _draw_nodes(canvas: Canvas, graph: Graph, layout: GridLayout, cs: CharSet) -
 def _draw_edges(
     canvas: Canvas, graph: Graph, layout: GridLayout, routed: list[RoutedEdge], cs: CharSet,
     rounded_edges: bool = True,
+    inline_edge_labels: bool = False,
 ) -> None:
     """Draw all edge lines, corners, arrows, and labels.
 
@@ -322,7 +331,11 @@ def _draw_edges(
     placed_labels: list[tuple[int, int, int]] = []  # (row, col_start, col_end)
     for re in routed:
         if re.label and len(re.draw_path) >= 2:
-            _draw_edge_label(canvas, re, placed_labels)
+            _draw_edge_label(
+                canvas, re, placed_labels,
+                inline=inline_edge_labels,
+                use_ascii=cs is ASCII,
+            )
 
 
 def _edge_line_chars(style: EdgeStyle, cs: CharSet) -> tuple[str, str]:
@@ -544,6 +557,9 @@ def _try_place_on_segment(
     prev_point: tuple[int, int] | None = None,
     prefer_left: bool = False,
     bias_target: bool = False,
+    inline: bool = False,
+    use_ascii: bool = False,
+    leader_char: str = "─",
 ) -> bool:
     """Try to place a label on a specific segment. Returns True if placed.
 
@@ -575,6 +591,33 @@ def _try_place_on_segment(
                 # Place label on the side the turn came from (inner side of the branch)
                 prefer_left = px > x1  # came from right → prefer left
 
+        if inline:
+            right_label = f"+-{label}" if use_ascii else f"├{leader_char}{label}"
+            left_label = f"{label}-+" if use_ascii else f"{label}{leader_char}┤"
+            sides = [
+                (mid_y, x1, right_label),
+                (mid_y, x1 - display_width(left_label) + 1, left_label),
+            ]
+            if prefer_left:
+                sides.reverse()
+
+            for row, col, anchored_label in sides:
+                if _try_place_label(
+                    canvas, row, col, anchored_label, placed_labels,
+                ):
+                    return True
+            for offset in range(1, 4):
+                for row, col, anchored_label in sides:
+                    if _try_place_label(
+                        canvas, row - offset, col, anchored_label, placed_labels,
+                    ):
+                        return True
+                    if _try_place_label(
+                        canvas, row + offset, col, anchored_label, placed_labels,
+                    ):
+                        return True
+            return False
+
         if prefer_left:
             sides = [
                 (mid_y, x1 - label_len),       # left
@@ -598,11 +641,16 @@ def _try_place_on_segment(
         return False
 
     if y1 == y2:
-        # Horizontal segment — center label above/below
+        # Horizontal segment — center inline labels on the edge, otherwise
+        # place labels above or below it.
         seg_len = abs(x2 - x1)
         if seg_len >= label_len + 2:
             mid = (min(x1, x2) + max(x1, x2)) // 2
             start = mid - label_len // 2
+            if inline:
+                return _try_place_label(
+                    canvas, y1, start, label, placed_labels,
+                )
             if _try_place_label(canvas, y1 - 1, start, label, placed_labels):
                 return True
             if _try_place_label(canvas, y1 + 1, start, label, placed_labels):
@@ -615,6 +663,9 @@ def _try_place_on_segment(
 def _draw_edge_label(
     canvas: Canvas, re: RoutedEdge,
     placed_labels: list[tuple[int, int, int]],
+    *,
+    inline: bool = False,
+    use_ascii: bool = False,
 ) -> None:
     """Draw an edge label on the best segment of the path.
 
@@ -627,6 +678,9 @@ def _draw_edge_label(
         return
 
     path = re.draw_path
+    leader_char = _edge_line_chars(
+        re.edge.style, ASCII if use_ascii else UNICODE,
+    )[0]
 
     # Build segment list ordered by preference: post-turn segments first,
     # then remaining segments in reverse order (end segments are more unique)
@@ -664,8 +718,19 @@ def _draw_edge_label(
             prev_point=prev,
             prefer_left=is_straight,
             bias_target=is_straight,
+            inline=inline,
+            use_ascii=use_ascii,
+            leader_char=leader_char,
         ):
             return
+
+    if inline:
+        _draw_edge_label(
+            canvas, re, placed_labels,
+            inline=False,
+            use_ascii=use_ascii,
+        )
+        return
 
     # Force place at midpoint of path
     mid_idx = len(path) // 2

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -155,6 +155,50 @@ class TestEdgeLabels:
         assert "No" in output
         assert "Maybe" in output
 
+    def test_labels_avoid_protected_nodes_and_routed_edges(self):
+        """Labels must move intact instead of leaving fragments over protected cells."""
+        output = render(
+            "flowchart LR\n"
+            "    User[User question] --> Model[Model]\n"
+            "    Model -->|search_web queries| Search[Internal search_web path]\n"
+            "    Search -->|results and reference IDs| Model\n"
+            "    Model -->|open ref_id list| Open[open runtime]\n"
+            "    Model -->|open direct URL| Open\n"
+            "    Open -->|page content with source identity| Model\n"
+            "    Model --> Answer[Grounded answer]",
+            padding_x=2,
+            padding_y=0,
+            gap=4,
+        )
+
+        for label in (
+            "search_web queries",
+            "results and reference IDs",
+            "open ref_id list",
+            "open direct URL",
+            "page content with source identity",
+        ):
+            assert label in output
+
+    def test_dotted_labels_avoid_crossing_routes(self):
+        """Dotted edge labels must remain intact around dense crossing routes."""
+        output = render(
+            "flowchart LR\n"
+            "    Search[Internal search_web] --> Grounding[Conversation grounding and citations]\n"
+            "    Grounding -. missing bridge .-> LuminaState[Lumina page-context state]\n"
+            "    Outputs[IToolExecutionOutputCollection] -. currently null on EDTI .-> Open[WebOpenToolExecutor]\n"
+            "    LuminaState --> Open\n"
+            "    Open --> Result[WebOpenResult]\n"
+            "    Result -. missing EDTI citation stage .-> CitationState[Registered citation state]",
+            padding_x=2,
+            padding_y=0,
+            gap=4,
+        )
+
+        assert "missing bridge" in output
+        assert "currently null on EDTI" in output
+        assert "missing EDTI citation stage" in output
+
 
 class TestSubgraphs:
     def test_basic_subgraph(self):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -45,6 +45,24 @@ class TestBasicRendering:
         assert isinstance(result, str)
         assert len(result) > 0
 
+    def test_inline_edge_labels_are_visibly_attached(self):
+        output = render(
+            "graph LR\n  A -->|edge label| B",
+            gap=16,
+            inline_edge_labels=True,
+        )
+
+        assert "─edge label─" in output
+
+    def test_inline_edge_labels_preserve_dotted_style(self):
+        output = render(
+            "graph LR\n  A -. dotted label .-> B",
+            gap=16,
+            inline_edge_labels=True,
+        )
+
+        assert "┄dotted label┄" in output
+
 
 class TestAllDirections:
     def test_lr(self):


### PR DESCRIPTION
## Summary
- prevent partial edge-label writes from leaving isolated characters
- preserve the existing forced-placement fallback while making it atomic
- let spaces in accepted labels clear connector characters cleanly
- add opt-in `--inline-edge-labels` rendering so labels sit directly on horizontal edges and remain visibly anchored to vertical edges
- preserve solid and dotted edge styles in inline mode
- document the new CLI option and add regression coverage

## Problem
Forced edge-label positions that crossed protected node content could previously write only the characters that fit, leaving isolated fragments such as a floating `o` or `m`. Separately, labels placed near dense routes could be difficult to associate with a particular edge.

## Solution
Label placement is now atomic: the complete label is validated before any character is written. The optional inline mode places labels directly on suitable edge segments, falls back to the regular placement strategy when a segment is too short, and does not add surrounding delimiters.

## Usage
```console
termaid diagram.mmd --inline-edge-labels --gap 8 --no-auto-fit
```

## Validation
- 1,154 passed, 13 skipped
- regressions cover the reported dense solid and dotted diagrams
- inline rendering covers solid and dotted edge styles