### PR TITLE
 ci: attach standalone per-platform binaries to releases

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,0 +1,86 @@
+# Fork-only: repackages the release's compiled binaries as npm packages under @tayomi/termaid-bin.
+# Deliberately a separate workflow from publish.yml, which stays clean for an upstream PR.
+#
+# It compiles NOTHING: the binaries job (publish.yml) uploads the assets to the release, and this
+# waits for the five of them, stages the packages (scripts/stage-npm.mjs), smokes one, publishes.
+# Needs the NPM_TOKEN secret (npm automation token with publish rights on the @tayomi scope).
+
+name: Publish npm binaries
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (vX.Y.Z) whose assets to package"
+        required: true
+
+permissions:
+  contents: read
+  id-token: write # npm --provenance
+
+env:
+  ASSET_COUNT: 5
+  WAIT_TRIES: 40
+  WAIT_SECONDS: 30
+
+jobs:
+  npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve tag
+        run: echo "TAG=${{ github.event.inputs.tag || github.event.release.tag_name }}" >> "$GITHUB_ENV"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Wait for the release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for i in $(seq 1 "$WAIT_TRIES"); do
+            count=$(gh release view "$TAG" --json assets --jq '[.assets[] | select(.name | startswith("termaid-"))] | length')
+            echo "assets: ${count}/${ASSET_COUNT} (try ${i}/${WAIT_TRIES})"
+            [ "$count" -ge "$ASSET_COUNT" ] && exit 0
+            sleep "$WAIT_SECONDS"
+          done
+          echo "the binaries job never delivered ${ASSET_COUNT} assets" >&2
+          exit 1
+
+      - name: Download the assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release download "$TAG" --pattern 'termaid-*' --dir assets
+
+      - name: Stage the packages
+        run: node scripts/stage-npm.mjs "${TAG#v}" assets dist-npm
+
+      - name: Smoke the binary this runner can execute
+        run: |
+          chmod +x dist-npm/termaid-bin-linux-x64/termaid
+          printf 'flowchart TD\n    A[Stage] --> B[Publish]\n' > _smoke.mmd
+          LC_ALL=C dist-npm/termaid-bin-linux-x64/termaid _smoke.mmd | grep -q Stage
+
+      - name: Publish, platforms first, meta last
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          version="${TAG#v}"
+          for dir in dist-npm/termaid-bin-*; do
+            name=$(node -p "require('./$dir/package.json').name")
+            if npm view "${name}@${version}" version >/dev/null 2>&1; then
+              echo "${name}@${version} already published, skipping"
+              continue
+            fi
+            npm publish --access public --provenance "./$dir"
+          done
+          if npm view "@tayomi/termaid-bin@${version}" version >/dev/null 2>&1; then
+            echo "meta already published, skipping"
+          else
+            npm publish --access public --provenance ./dist-npm/termaid-bin
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,3 +20,87 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  binaries:
+    name: Build binary (${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container }}
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: darwin-arm64
+            runner: macos-latest
+          - target: darwin-x64
+            runner: macos-15-intel
+          - target: linux-x64
+            runner: ubuntu-latest
+            container: quay.io/pypa/manylinux_2_28_x86_64
+          - target: linux-arm64
+            runner: ubuntu-24.04-arm
+            container: quay.io/pypa/manylinux_2_28_aarch64
+          - target: windows-x64
+            runner: windows-latest
+            ext: .exe
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        if: ${{ !matrix.container }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Set up Python (manylinux)
+        if: ${{ matrix.container }}
+        run: |
+          echo "/opt/python/cp313-cp313/bin" >> "$GITHUB_PATH"
+          cd /opt/_internal && tar xf static-libs-for-embedding-only.tar.xz
+
+      - name: Install Nuitka and termaid
+        shell: bash
+        run: python -m pip install nuitka '.[rich]'
+
+      - name: Compile binary
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          {
+            echo 'import sys'
+            echo 'sys.stdout.reconfigure(encoding="utf-8")'
+            echo 'sys.stderr.reconfigure(encoding="utf-8")'
+            echo 'from termaid.cli import main'
+            echo 'main()'
+          } > _entry.py
+          python -m nuitka --onefile \
+            --onefile-tempdir-spec='{CACHE_DIR}/termaid/{VERSION}' \
+            --product-version="$version" \
+            --include-package=termaid \
+            --include-package=rich \
+            --output-dir=build \
+            --output-filename=termaid \
+            --assume-yes-for-downloads \
+            _entry.py
+          mv "build/termaid${{ matrix.ext }}" "termaid-${{ matrix.target }}${{ matrix.ext }}"
+
+      - name: Smoke test
+        shell: bash
+        run: |
+          printf 'flowchart TD\n    A[Build] --> B[Release]\n' > _smoke.mmd
+          LC_ALL=C "./termaid-${{ matrix.target }}${{ matrix.ext }}" _smoke.mmd | grep -q Build
+
+      - name: Upload to release
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          upload_url="${{ github.event.release.upload_url }}"
+          upload_url="${upload_url%\{*}"
+          asset="termaid-${{ matrix.target }}${{ matrix.ext }}"
+          curl --fail -sS -X POST \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Content-Type: application/octet-stream" \
+            --data-binary "@${asset}" \
+            "${upload_url}?name=${asset}"

--- a/npm/termaid-bin/README.md
+++ b/npm/termaid-bin/README.md
@@ -1,0 +1,19 @@
+# @tayomi/termaid-bin
+
+Unofficial prebuilt binaries of [termaid](https://github.com/fasouto/termaid) by Fabio Souto: Mermaid diagrams rendered as Unicode art in the terminal, without needing Python installed.
+
+This package authors nothing: it repackages binaries compiled (Nuitka) by the CI of [mopi1402/termaid](https://github.com/mopi1402/termaid), a fork that only adds the build pipeline. All credit for termaid itself goes to its author. MIT, upstream license included.
+
+## How it works
+
+Installing this package pulls exactly one `optionalDependency`: the platform package matching your `os`/`cpu` (darwin-arm64, darwin-x64, linux-x64, linux-arm64, win32-x64). The binary arrives through npm, integrity-checked by your lockfile, with no postinstall script and no network fetch at runtime.
+
+```js
+const { termaidPath } = require("@tayomi/termaid-bin");
+
+termaidPath(); // absolute path of the binary, or null on an unsupported platform
+```
+
+```sh
+$(node -p 'require("@tayomi/termaid-bin").termaidPath()') --demo flowchart
+```

--- a/npm/termaid-bin/index.js
+++ b/npm/termaid-bin/index.js
@@ -1,0 +1,36 @@
+// Resolves the termaid binary this machine's optional platform package installed.
+// CommonJS on purpose: consumable by require() and import alike, on any Node still in service.
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+// npm's own platform words (process.platform / process.arch), which the os/cpu fields already speak.
+const PLATFORMS = {
+  "darwin arm64": "@tayomi/termaid-bin-darwin-arm64",
+  "darwin x64": "@tayomi/termaid-bin-darwin-x64",
+  "linux x64": "@tayomi/termaid-bin-linux-x64",
+  "linux arm64": "@tayomi/termaid-bin-linux-arm64",
+  "win32 x64": "@tayomi/termaid-bin-win32-x64",
+};
+
+const BINARY = process.platform === "win32" ? "termaid.exe" : "termaid";
+
+/**
+ * Absolute path of the installed termaid binary, or null: unsupported platform, or the optional
+ * dependency was skipped (--no-optional, unsupported os/cpu, offline install).
+ */
+function termaidPath() {
+  const pkg = PLATFORMS[`${process.platform} ${process.arch}`];
+  if (pkg === undefined) return null;
+  let dir;
+  try {
+    dir = path.dirname(require.resolve(`${pkg}/package.json`));
+  } catch {
+    return null;
+  }
+  const bin = path.join(dir, BINARY);
+  return fs.existsSync(bin) ? bin : null;
+}
+
+module.exports = { termaidPath };

--- a/npm/termaid-bin/package.json
+++ b/npm/termaid-bin/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@tayomi/termaid-bin",
+  "version": "0.0.0",
+  "description": "Unofficial prebuilt binaries of termaid (Mermaid diagrams as Unicode art in the terminal). termaid is by Fabio Souto; this package only redistributes compiled binaries.",
+  "license": "MIT",
+  "main": "index.js",
+  "files": [
+    "index.js"
+  ],
+  "optionalDependencies": {},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mopi1402/termaid.git"
+  },
+  "homepage": "https://github.com/fasouto/termaid",
+  "keywords": [
+    "termaid",
+    "mermaid",
+    "terminal",
+    "diagram",
+    "prebuilt",
+    "binary"
+  ]
+}

--- a/scripts/stage-npm.mjs
+++ b/scripts/stage-npm.mjs
@@ -1,0 +1,76 @@
+// Stages the npm packages for one release: five platform packages, each carrying one compiled binary,
+// and the @tayomi/termaid-bin meta package pinning them as optionalDependencies.
+//
+// Shared by the CI and a local dry-run, so what publishes is exactly what was rehearsed:
+//   node scripts/stage-npm.mjs <version> <assets-dir> <out-dir>
+// <assets-dir> holds the release assets (termaid-<target>[.exe]) the binaries job uploaded.
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const META_SRC = path.join(ROOT, "npm", "termaid-bin");
+const LICENSE = path.join(ROOT, "LICENSE");
+const SCOPE = "@tayomi/termaid-bin";
+const UPSTREAM = "https://github.com/fasouto/termaid";
+const FORK = "git+https://github.com/mopi1402/termaid.git";
+const EXEC_MODE = 0o755;
+
+// Asset names speak the CI matrix's words, package names speak npm's (process.platform / os,cpu).
+const TARGETS = [
+  { asset: "termaid-darwin-arm64", suffix: "darwin-arm64", os: "darwin", cpu: "arm64", bin: "termaid" },
+  { asset: "termaid-darwin-x64", suffix: "darwin-x64", os: "darwin", cpu: "x64", bin: "termaid" },
+  { asset: "termaid-linux-x64", suffix: "linux-x64", os: "linux", cpu: "x64", bin: "termaid" },
+  { asset: "termaid-linux-arm64", suffix: "linux-arm64", os: "linux", cpu: "arm64", bin: "termaid" },
+  { asset: "termaid-windows-x64.exe", suffix: "win32-x64", os: "win32", cpu: "x64", bin: "termaid.exe" },
+];
+
+const [version, assetsDir, outDir] = process.argv.slice(2);
+if (!version || !assetsDir || !outDir) {
+  console.error("usage: node scripts/stage-npm.mjs <version> <assets-dir> <out-dir>");
+  process.exit(1);
+}
+
+const write = (dir, name, value) =>
+  fs.writeFileSync(path.join(dir, name), `${JSON.stringify(value, null, 2)}\n`);
+
+const pins = {};
+for (const t of TARGETS) {
+  const name = `${SCOPE}-${t.suffix}`;
+  const src = path.join(assetsDir, t.asset);
+  if (!fs.existsSync(src)) {
+    console.error(`stage-npm: missing asset ${src}`);
+    process.exit(1);
+  }
+  const dir = path.join(outDir, `termaid-bin-${t.suffix}`);
+  fs.mkdirSync(dir, { recursive: true });
+  write(dir, "package.json", {
+    name,
+    version,
+    description: `Unofficial prebuilt termaid binary (${t.suffix}). termaid is by Fabio Souto (${UPSTREAM}); this package only redistributes a compiled binary.`,
+    license: "MIT",
+    os: [t.os],
+    cpu: [t.cpu],
+    files: [t.bin],
+    repository: { type: "git", url: FORK },
+    homepage: UPSTREAM,
+  });
+  fs.copyFileSync(src, path.join(dir, t.bin));
+  fs.chmodSync(path.join(dir, t.bin), EXEC_MODE);
+  fs.copyFileSync(LICENSE, path.join(dir, "LICENSE"));
+  pins[name] = version;
+}
+
+// The meta package: sources copied as written, version and exact pins stamped. Exact on purpose:
+// a meta at X installing a platform at Y is two releases pretending to be one.
+const meta = path.join(outDir, "termaid-bin");
+fs.mkdirSync(meta, { recursive: true });
+for (const f of fs.readdirSync(META_SRC)) fs.copyFileSync(path.join(META_SRC, f), path.join(meta, f));
+fs.copyFileSync(LICENSE, path.join(meta, "LICENSE"));
+const pkg = JSON.parse(fs.readFileSync(path.join(meta, "package.json"), "utf8"));
+pkg.version = version;
+pkg.optionalDependencies = pins;
+write(meta, "package.json", pkg);
+
+console.log(`stage-npm: staged ${TARGETS.length} platform packages + meta at ${version} in ${outDir}`);


### PR DESCRIPTION
 Implements #7.

  One job in `publish.yml`, on the existing release trigger: Nuitka compiles five
  targets and uploads them as release assets. No source change, no dependency, no
  secret. The job is independent of `pypi` and can fail without affecting it.

  Linux targets are built in `manylinux_2_28` (glibc 2.17+), `rich` is embedded so
  `--theme` works, and every binary is smoke-tested before upload.

  Validated on a fork: https://github.com/mopi1402/termaid/releases/tag/0.8.0